### PR TITLE
Implement comprehensive cluster report and deprecate analytics page

### DIFF
--- a/core/clustering/bridges.py
+++ b/core/clustering/bridges.py
@@ -1,0 +1,345 @@
+"""
+Bridge-builder identification and analysis.
+
+Identifies voters who connect different opinion clusters, acting as bridges
+between bubbles. These voters have voting patterns similar to multiple clusters.
+
+Key insight: "Some people naturally connect different perspectives."
+"""
+
+import numpy as np
+from collections import defaultdict
+from sklearn.metrics.pairwise import euclidean_distances
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def identify_bridge_builders(run, distance_threshold=0.5, min_connections=2):
+    """
+    Identify voters who act as bridges between clusters.
+    
+    A bridge-builder is someone whose projection is close to multiple cluster
+    centroids, indicating they share voting patterns with different groups.
+    
+    Args:
+        run: VoterClusterRun instance
+        distance_threshold: max distance to centroid to be considered "close"
+        min_connections: minimum number of clusters to connect
+    
+    Returns:
+        list of dict: [
+            {
+                'voter_type': 'user'|'session',
+                'voter_id': str,
+                'assigned_cluster': int,
+                'connected_clusters': [1, 3, 4],  # cluster IDs
+                'distances': {1: 0.3, 3: 0.45, 4: 0.4},
+                'bridge_strength': float (0-1),  # higher = stronger bridge
+                'n_votes': int,
+                'projection_x': float,
+                'projection_y': float,
+            }
+        ]
+    """
+    clusters = run.clusters.filter(cluster_type='group').prefetch_related('members')
+    projections = run.projections.all()
+    
+    if not clusters.exists() or not projections.exists():
+        logger.warning(f"No data for bridge analysis in run {run.id}")
+        return []
+    
+    # Build centroid positions
+    cluster_centroids = {}
+    for cluster in clusters:
+        cluster_centroids[cluster.cluster_id] = np.array([
+            cluster.centroid_x,
+            cluster.centroid_y
+        ])
+    
+    # Build voter assignment map
+    voter_clusters = {}
+    for cluster in clusters:
+        for member in cluster.members.all():
+            key = f"{member.voter_type}:{member.voter_id}"
+            voter_clusters[key] = cluster.cluster_id
+    
+    # Analyze each voter
+    bridges = []
+    
+    for proj in projections:
+        voter_key = f"{proj.voter_type}:{proj.voter_id}"
+        assigned_cluster = voter_clusters.get(voter_key)
+        
+        if assigned_cluster is None:
+            continue
+        
+        voter_pos = np.array([proj.projection_x, proj.projection_y])
+        
+        # Calculate distance to all centroids
+        distances = {}
+        for cluster_id, centroid in cluster_centroids.items():
+            dist = np.linalg.norm(voter_pos - centroid)
+            distances[cluster_id] = float(dist)
+        
+        # Find clusters within threshold
+        connected = [
+            cid for cid, dist in distances.items()
+            if dist <= distance_threshold
+        ]
+        
+        # Must connect at least min_connections clusters
+        if len(connected) < min_connections:
+            continue
+        
+        # Calculate bridge strength
+        # Stronger bridge = closer to multiple centroids
+        # Normalize by average distance to connected centroids
+        avg_distance = np.mean([distances[cid] for cid in connected])
+        bridge_strength = 1.0 - (avg_distance / distance_threshold)
+        bridge_strength = max(0.0, min(1.0, bridge_strength))
+        
+        bridges.append({
+            'voter_type': proj.voter_type,
+            'voter_id': proj.voter_id,
+            'assigned_cluster': assigned_cluster,
+            'connected_clusters': connected,
+            'distances': distances,
+            'bridge_strength': float(bridge_strength),
+            'n_votes': proj.n_votes_cast,
+            'projection_x': float(proj.projection_x),
+            'projection_y': float(proj.projection_y),
+        })
+    
+    # Sort by bridge strength (strongest first)
+    bridges.sort(key=lambda x: x['bridge_strength'], reverse=True)
+    
+    logger.info(f"Identified {len(bridges)} bridge-builders in run {run.id}")
+    
+    return bridges
+
+
+def calculate_bridge_strength(projection, centroid_a, centroid_b):
+    """
+    Calculate how well a voter bridges two specific clusters.
+    
+    Args:
+        projection: (x, y) tuple
+        centroid_a: (x, y) tuple
+        centroid_b: (x, y) tuple
+    
+    Returns:
+        float: bridge strength (0-1)
+            1.0 = exactly between the two centroids
+            0.0 = far from both
+    """
+    proj = np.array(projection)
+    cent_a = np.array(centroid_a)
+    cent_b = np.array(centroid_b)
+    
+    # Distance to each centroid
+    dist_a = np.linalg.norm(proj - cent_a)
+    dist_b = np.linalg.norm(proj - cent_b)
+    
+    # Distance between centroids
+    centroid_distance = np.linalg.norm(cent_a - cent_b)
+    
+    if centroid_distance == 0:
+        return 0.0
+    
+    # Ideal bridge position is midpoint
+    midpoint = (cent_a + cent_b) / 2
+    dist_to_midpoint = np.linalg.norm(proj - midpoint)
+    
+    # Normalize by centroid distance
+    # Closer to midpoint = stronger bridge
+    normalized_distance = dist_to_midpoint / (centroid_distance / 2)
+    strength = max(0.0, 1.0 - normalized_distance)
+    
+    return float(strength)
+
+
+def build_bridge_network_data(run, distance_threshold=0.5):
+    """
+    Build network graph data for visualization.
+    
+    Creates nodes (clusters + bridges) and edges (connections).
+    
+    Args:
+        run: VoterClusterRun instance
+        distance_threshold: threshold for bridge identification
+    
+    Returns:
+        dict: {
+            'nodes': [
+                {
+                    'id': 'cluster_1',
+                    'type': 'cluster',
+                    'label': 'Burbuja A',
+                    'size': 100,
+                    'x': 0.5,
+                    'y': 0.3,
+                },
+                {
+                    'id': 'voter_session:abc',
+                    'type': 'bridge',
+                    'strength': 0.8,
+                    'n_votes': 45,
+                    'x': 0.4,
+                    'y': 0.35,
+                },
+            ],
+            'edges': [
+                {
+                    'source': 'voter_session:abc',
+                    'target': 'cluster_1',
+                    'weight': 0.7,
+                },
+            ]
+        }
+    """
+    clusters = run.clusters.filter(cluster_type='group')
+    bridges = identify_bridge_builders(run, distance_threshold=distance_threshold)
+    
+    nodes = []
+    edges = []
+    
+    # Add cluster nodes
+    for cluster in clusters:
+        nodes.append({
+            'id': f'cluster_{cluster.cluster_id}',
+            'type': 'cluster',
+            'label': cluster.llm_name or f'Burbuja {cluster.cluster_id}',
+            'description': cluster.llm_description or '',
+            'size': cluster.size,
+            'x': float(cluster.centroid_x),
+            'y': float(cluster.centroid_y),
+            'cluster_id': cluster.cluster_id,
+        })
+    
+    # Add bridge nodes (limit to top bridges for visualization clarity)
+    top_bridges = bridges[:50]  # Top 50 strongest bridges
+    
+    for bridge in top_bridges:
+        voter_id = f"{bridge['voter_type']}:{bridge['voter_id']}"
+        
+        nodes.append({
+            'id': f'voter_{voter_id}',
+            'type': 'bridge',
+            'strength': bridge['bridge_strength'],
+            'n_votes': bridge['n_votes'],
+            'x': bridge['projection_x'],
+            'y': bridge['projection_y'],
+            'assigned_cluster': bridge['assigned_cluster'],
+            'connected_clusters': bridge['connected_clusters'],
+        })
+        
+        # Add edges to connected clusters
+        for cluster_id in bridge['connected_clusters']:
+            distance = bridge['distances'][cluster_id]
+            weight = 1.0 - (distance / distance_threshold)  # Closer = stronger edge
+            
+            edges.append({
+                'source': f'voter_{voter_id}',
+                'target': f'cluster_{cluster_id}',
+                'weight': float(weight),
+                'distance': float(distance),
+            })
+    
+    return {
+        'nodes': nodes,
+        'edges': edges,
+        'n_clusters': len(nodes) - len(top_bridges),
+        'n_bridges': len(top_bridges),
+    }
+
+
+def analyze_bridge_activity(bridges):
+    """
+    Analyze voting activity patterns of bridge-builders.
+    
+    Args:
+        bridges: list from identify_bridge_builders()
+    
+    Returns:
+        dict: {
+            'total_bridges': int,
+            'avg_votes': float,
+            'avg_connections': float,
+            'strongest_bridge': dict,
+            'most_active_bridge': dict,
+        }
+    """
+    if not bridges:
+        return {
+            'total_bridges': 0,
+            'avg_votes': 0.0,
+            'avg_connections': 0.0,
+            'strongest_bridge': None,
+            'most_active_bridge': None,
+        }
+    
+    total = len(bridges)
+    avg_votes = np.mean([b['n_votes'] for b in bridges])
+    avg_connections = np.mean([len(b['connected_clusters']) for b in bridges])
+    
+    strongest = max(bridges, key=lambda b: b['bridge_strength'])
+    most_active = max(bridges, key=lambda b: b['n_votes'])
+    
+    return {
+        'total_bridges': total,
+        'avg_votes': float(avg_votes),
+        'avg_connections': float(avg_connections),
+        'strongest_bridge': strongest,
+        'most_active_bridge': most_active,
+    }
+
+
+def get_bridge_vote_examples(run, bridge_voter_key, limit=10):
+    """
+    Get example votes from a bridge-builder to understand their pattern.
+    
+    Args:
+        run: VoterClusterRun instance
+        bridge_voter_key: "user:123" or "session:abc"
+        limit: number of votes to return
+    
+    Returns:
+        list of dict: vote examples with cluster opinions
+    """
+    from core.models import Voto, VoterClusterMembership
+    
+    voter_type, voter_id = bridge_voter_key.split(':', 1)
+    
+    # Get this voter's votes
+    if voter_type == 'user':
+        votes = Voto.objects.filter(usuario_id=voter_id)
+    else:
+        votes = Voto.objects.filter(session_key=voter_id)
+    
+    votes = votes.select_related('noticia').order_by('-fecha_voto')[:limit]
+    
+    # Get cluster opinions on same noticias
+    clusters = run.clusters.filter(cluster_type='group')
+    
+    examples = []
+    for vote in votes:
+        # Get how each cluster voted on this noticia
+        cluster_opinions = {}
+        
+        for cluster in clusters:
+            pattern = cluster.voting_patterns.filter(noticia=vote.noticia).first()
+            if pattern:
+                cluster_opinions[cluster.cluster_id] = {
+                    'majority': pattern.majority_opinion,
+                    'consensus': pattern.consensus_score,
+                }
+        
+        examples.append({
+            'noticia': vote.noticia,
+            'bridge_vote': vote.opinion,
+            'cluster_opinions': cluster_opinions,
+            'fecha': vote.fecha_voto,
+        })
+    
+    return examples

--- a/core/clustering/consensus.py
+++ b/core/clustering/consensus.py
@@ -1,0 +1,288 @@
+"""
+Cross-cluster consensus analysis.
+
+Identifies news articles that generate agreement or division across bubbles.
+Key insight: "We agree more than we think."
+
+References:
+- Polis consensus/divisive statements methodology
+- See SCIENTIFIC.md for clustering foundations
+"""
+
+import numpy as np
+from collections import defaultdict, Counter
+from django.db.models import Count, Q, Prefetch
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def calculate_cross_cluster_consensus(run, min_votes_per_cluster=3):
+    """
+    Calculate consensus score for each noticia across all clusters.
+    
+    High consensus = most clusters vote similarly.
+    Low consensus (divisive) = clusters disagree.
+    
+    Args:
+        run: VoterClusterRun instance
+        min_votes_per_cluster: minimum votes per cluster to consider noticia
+    
+    Returns:
+        list of dict: [
+            {
+                'noticia': Noticia instance,
+                'noticia_id': int,
+                'consensus_score': float (0-1),
+                'polarization_score': float (0-1),
+                'cluster_votes': {
+                    cluster_id: {
+                        'buena': 0.7,  # proportion
+                        'mala': 0.2,
+                        'neutral': 0.1,
+                        'total_votes': 20
+                    }
+                },
+                'majority_opinion': 'buena'|'mala'|'neutral',
+                'agreement_rate': float (0-1),  # % of clusters agreeing with majority
+            }
+        ]
+    """
+    from core.models import Noticia, Voto
+    
+    clusters = run.clusters.filter(cluster_type='group').prefetch_related('members')
+    
+    if not clusters.exists():
+        logger.warning(f"No group clusters found for run {run.id}")
+        return []
+    
+    # Build map of voter_id -> cluster_id
+    voter_to_cluster = {}
+    for cluster in clusters:
+        for member in cluster.members.all():
+            key = f"{member.voter_type}:{member.voter_id}"
+            voter_to_cluster[key] = cluster.cluster_id
+    
+    # Get all votes for voters in this clustering
+    all_votes = Voto.objects.select_related('noticia').all()
+    
+    # Aggregate votes by noticia and cluster
+    noticia_cluster_votes = defaultdict(lambda: defaultdict(lambda: {'buena': 0, 'mala': 0, 'neutral': 0}))
+    
+    for vote in all_votes:
+        # Identify voter
+        if vote.usuario_id:
+            voter_key = f"user:{vote.usuario_id}"
+        elif vote.session_key:
+            voter_key = f"session:{vote.session_key}"
+        else:
+            continue
+        
+        cluster_id = voter_to_cluster.get(voter_key)
+        if cluster_id is None:
+            continue
+        
+        noticia_cluster_votes[vote.noticia_id][cluster_id][vote.opinion] += 1
+    
+    # Calculate consensus metrics for each noticia
+    results = []
+    
+    for noticia_id, cluster_data in noticia_cluster_votes.items():
+        # Filter: need minimum votes per cluster
+        valid_clusters = {
+            cid: votes for cid, votes in cluster_data.items()
+            if sum(votes.values()) >= min_votes_per_cluster
+        }
+        
+        if len(valid_clusters) < 2:  # Need at least 2 clusters for consensus
+            continue
+        
+        # Calculate proportions for each cluster
+        cluster_votes = {}
+        cluster_majorities = []
+        
+        for cluster_id, votes in valid_clusters.items():
+            total = sum(votes.values())
+            proportions = {
+                'buena': votes['buena'] / total,
+                'mala': votes['mala'] / total,
+                'neutral': votes['neutral'] / total,
+                'total_votes': total
+            }
+            cluster_votes[cluster_id] = proportions
+            
+            # Majority opinion for this cluster
+            majority = max(proportions.items(), key=lambda x: x[0] != 'total_votes' and x[1])
+            cluster_majorities.append(majority[0])
+        
+        # Overall majority across all clusters
+        majority_counter = Counter(cluster_majorities)
+        overall_majority = majority_counter.most_common(1)[0][0]
+        agreement_rate = majority_counter[overall_majority] / len(cluster_majorities)
+        
+        # Consensus score: how much do clusters agree?
+        # High = most clusters have same majority opinion
+        consensus_score = agreement_rate
+        
+        # Polarization score: variance in opinions across clusters
+        # Extract buena proportions for variance calculation
+        buena_proportions = [cv['buena'] for cv in cluster_votes.values()]
+        polarization_score = float(np.var(buena_proportions))
+        
+        try:
+            noticia = Noticia.objects.get(id=noticia_id)
+        except Noticia.DoesNotExist:
+            continue
+        
+        results.append({
+            'noticia': noticia,
+            'noticia_id': noticia_id,
+            'consensus_score': consensus_score,
+            'polarization_score': polarization_score,
+            'cluster_votes': cluster_votes,
+            'majority_opinion': overall_majority,
+            'agreement_rate': agreement_rate,
+            'n_clusters_voted': len(valid_clusters),
+        })
+    
+    # Sort by consensus score (highest first)
+    results.sort(key=lambda x: x['consensus_score'], reverse=True)
+    
+    return results
+
+
+def calculate_divisive_news(run, min_votes_per_cluster=3, top_n=20):
+    """
+    Identify the most divisive news articles.
+    
+    Divisive = high polarization, clusters disagree strongly.
+    
+    Args:
+        run: VoterClusterRun instance
+        min_votes_per_cluster: minimum votes to consider
+        top_n: return top N most divisive
+    
+    Returns:
+        list of dict: same structure as calculate_cross_cluster_consensus
+    """
+    all_results = calculate_cross_cluster_consensus(run, min_votes_per_cluster)
+    
+    # Sort by polarization (highest first)
+    divisive = sorted(all_results, key=lambda x: x['polarization_score'], reverse=True)
+    
+    return divisive[:top_n]
+
+
+def calculate_consensus_news(run, min_votes_per_cluster=3, consensus_threshold=0.7, top_n=20):
+    """
+    Identify news with highest cross-cluster consensus.
+    
+    Args:
+        run: VoterClusterRun instance
+        min_votes_per_cluster: minimum votes to consider
+        consensus_threshold: minimum agreement rate
+        top_n: return top N
+    
+    Returns:
+        list of dict: news with high consensus
+    """
+    all_results = calculate_cross_cluster_consensus(run, min_votes_per_cluster)
+    
+    # Filter by consensus threshold
+    consensus_news = [r for r in all_results if r['consensus_score'] >= consensus_threshold]
+    
+    # Already sorted by consensus_score
+    return consensus_news[:top_n]
+
+
+def calculate_polarization_score(run):
+    """
+    Calculate overall polarization score for a clustering run.
+    
+    Returns:
+        dict: {
+            'polarization_score': float (0-1),
+            'consensus_score': float (0-1),
+            'n_consensus_news': int,
+            'n_divisive_news': int,
+            'n_total_news': int,
+        }
+    """
+    all_results = calculate_cross_cluster_consensus(run, min_votes_per_cluster=3)
+    
+    if not all_results:
+        return {
+            'polarization_score': 0.0,
+            'consensus_score': 0.0,
+            'n_consensus_news': 0,
+            'n_divisive_news': 0,
+            'n_total_news': 0,
+        }
+    
+    # Average polarization
+    avg_polarization = np.mean([r['polarization_score'] for r in all_results])
+    avg_consensus = np.mean([r['consensus_score'] for r in all_results])
+    
+    # Count consensus vs divisive
+    n_consensus = len([r for r in all_results if r['consensus_score'] >= 0.7])
+    n_divisive = len([r for r in all_results if r['polarization_score'] >= 0.15])
+    
+    return {
+        'polarization_score': float(avg_polarization),
+        'consensus_score': float(avg_consensus),
+        'n_consensus_news': n_consensus,
+        'n_divisive_news': n_divisive,
+        'n_total_news': len(all_results),
+    }
+
+
+def get_consensus_by_entity_type(run):
+    """
+    Analyze consensus patterns by entity type (personas, organizaciones, lugares).
+    
+    Returns:
+        dict: {
+            'personas': {'consensus': 0.8, 'polarization': 0.1},
+            'organizaciones': {'consensus': 0.6, 'polarization': 0.2},
+            'lugares': {'consensus': 0.7, 'polarization': 0.15},
+        }
+    """
+    from core.models import NoticiaEntidad
+    
+    consensus_results = calculate_cross_cluster_consensus(run, min_votes_per_cluster=3)
+    
+    # Map noticia_id -> metrics
+    noticia_metrics = {
+        r['noticia_id']: {
+            'consensus': r['consensus_score'],
+            'polarization': r['polarization_score']
+        }
+        for r in consensus_results
+    }
+    
+    # Group by entity type
+    entity_types = ['persona', 'organizacion', 'lugar']
+    results = {}
+    
+    for entity_type in entity_types:
+        # Get noticias with this entity type
+        noticias_with_type = NoticiaEntidad.objects.filter(
+            entidad__tipo=entity_type,
+            noticia_id__in=noticia_metrics.keys()
+        ).values_list('noticia_id', flat=True).distinct()
+        
+        if noticias_with_type:
+            metrics = [noticia_metrics[nid] for nid in noticias_with_type]
+            results[entity_type] = {
+                'consensus': float(np.mean([m['consensus'] for m in metrics])),
+                'polarization': float(np.mean([m['polarization'] for m in metrics])),
+                'n_news': len(metrics),
+            }
+        else:
+            results[entity_type] = {
+                'consensus': 0.0,
+                'polarization': 0.0,
+                'n_news': 0,
+            }
+    
+    return results

--- a/core/clustering/evolution.py
+++ b/core/clustering/evolution.py
@@ -1,0 +1,440 @@
+"""
+Temporal evolution and stability analysis of clusters.
+
+Tracks how clusters change over time: splits, merges, stability, opinion drift.
+
+Key insight: "Understanding how opinion clusters evolve reveals societal shifts."
+"""
+
+import numpy as np
+from collections import defaultdict
+from datetime import timedelta
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def calculate_stability_index(run1, run2):
+    """
+    Compare two consecutive clustering runs to measure stability.
+    
+    High stability = voters stay in same clusters
+    Low stability = major reshuffling
+    
+    Args:
+        run1: Earlier VoterClusterRun
+        run2: Later VoterClusterRun
+    
+    Returns:
+        dict: {
+            'voter_retention': float (0-1),  # % voters in same relative cluster
+            'cluster_persistence': [
+                {
+                    'run1_cluster_id': 1,
+                    'run2_cluster_id': 2,
+                    'retention': 0.88,
+                    'overlap_count': 45,
+                    'relationship': 'continuation'|'split'|'merge'|'new'
+                },
+            ],
+            'stability_score': float (0-1),  # overall stability
+        }
+    """
+    # Get memberships for both runs
+    clusters1 = run1.clusters.filter(cluster_type='group').prefetch_related('members')
+    clusters2 = run2.clusters.filter(cluster_type='group').prefetch_related('members')
+    
+    # Build voter -> cluster maps
+    memberships1 = defaultdict(set)  # cluster_id -> set of voter keys
+    memberships2 = defaultdict(set)
+    
+    for cluster in clusters1:
+        for member in cluster.members.all():
+            voter_key = f'{member.voter_type}:{member.voter_id}'
+            memberships1[cluster.cluster_id].add(voter_key)
+    
+    for cluster in clusters2:
+        for member in cluster.members.all():
+            voter_key = f'{member.voter_type}:{member.voter_id}'
+            memberships2[cluster.cluster_id].add(voter_key)
+    
+    # Find common voters
+    voters1 = set().union(*memberships1.values())
+    voters2 = set().union(*memberships2.values())
+    common_voters = voters1 & voters2
+    
+    if not common_voters:
+        return {
+            'voter_retention': 0.0,
+            'cluster_persistence': [],
+            'stability_score': 0.0,
+        }
+    
+    # Build inverse maps (voter -> cluster_id)
+    voter_to_cluster1 = {}
+    voter_to_cluster2 = {}
+    
+    for cid, voters in memberships1.items():
+        for voter in voters:
+            voter_to_cluster1[voter] = cid
+    
+    for cid, voters in memberships2.items():
+        for voter in voters:
+            voter_to_cluster2[voter] = cid
+    
+    # Calculate overlap matrix
+    overlap_matrix = defaultdict(lambda: defaultdict(int))
+    
+    for voter in common_voters:
+        c1 = voter_to_cluster1.get(voter)
+        c2 = voter_to_cluster2.get(voter)
+        if c1 is not None and c2 is not None:
+            overlap_matrix[c1][c2] += 1
+    
+    # Analyze each cluster pair
+    cluster_persistence = []
+    
+    for c1_id in memberships1.keys():
+        c1_voters = memberships1[c1_id]
+        c1_common = c1_voters & common_voters
+        
+        if not c1_common:
+            continue
+        
+        # Find best matching cluster in run2
+        best_overlap = 0
+        best_c2 = None
+        
+        for c2_id in memberships2.keys():
+            overlap = overlap_matrix[c1_id][c2_id]
+            if overlap > best_overlap:
+                best_overlap = overlap
+                best_c2 = c2_id
+        
+        if best_c2 is None:
+            continue
+        
+        c2_voters = memberships2[best_c2]
+        c2_common = c2_voters & common_voters
+        
+        # Calculate retention rate
+        retention_from_c1 = best_overlap / len(c1_common) if c1_common else 0
+        retention_from_c2 = best_overlap / len(c2_common) if c2_common else 0
+        
+        # Determine relationship type
+        if retention_from_c1 > 0.8 and retention_from_c2 > 0.8:
+            relationship = 'continuation'
+        elif retention_from_c1 > 0.5 and retention_from_c2 < 0.7:
+            relationship = 'split'
+        elif retention_from_c1 < 0.7 and retention_from_c2 > 0.5:
+            relationship = 'merge'
+        else:
+            relationship = 'shuffle'
+        
+        cluster_persistence.append({
+            'run1_cluster_id': c1_id,
+            'run2_cluster_id': best_c2,
+            'retention_from_run1': float(retention_from_c1),
+            'retention_from_run2': float(retention_from_c2),
+            'overlap_count': best_overlap,
+            'relationship': relationship,
+        })
+    
+    # Overall stability: weighted average of retention rates
+    if cluster_persistence:
+        total_voters = sum(cp['overlap_count'] for cp in cluster_persistence)
+        weighted_retention = sum(
+            cp['overlap_count'] * cp['retention_from_run1']
+            for cp in cluster_persistence
+        ) / total_voters if total_voters > 0 else 0
+    else:
+        weighted_retention = 0
+    
+    return {
+        'voter_retention': float(weighted_retention),
+        'cluster_persistence': cluster_persistence,
+        'stability_score': float(weighted_retention),
+        'n_common_voters': len(common_voters),
+        'n_voters_run1': len(voters1),
+        'n_voters_run2': len(voters2),
+    }
+
+
+def track_cluster_lineage(runs, min_overlap=5):
+    """
+    Track cluster lineage across multiple runs.
+    
+    Builds a graph showing how clusters split, merge, and evolve.
+    
+    Args:
+        runs: list of VoterClusterRun instances (ordered by time)
+        min_overlap: minimum voter overlap to consider relationship
+    
+    Returns:
+        list of dict: [
+            {
+                'run_id': int,
+                'cluster_id': int,
+                'predecessors': [{'run_id': int, 'cluster_id': int, 'overlap': int}],
+                'successors': [{'run_id': int, 'cluster_id': int, 'overlap': int}],
+                'stability': float,
+            }
+        ]
+    """
+    lineage = []
+    
+    for i, run in enumerate(runs):
+        clusters = run.clusters.filter(cluster_type='group').prefetch_related('members')
+        
+        # Build membership for this run
+        memberships = defaultdict(set)
+        for cluster in clusters:
+            for member in cluster.members.all():
+                voter_key = f'{member.voter_type}:{member.voter_id}'
+                memberships[cluster.cluster_id].add(voter_key)
+        
+        # Compare with previous run
+        predecessors_map = defaultdict(list)
+        if i > 0:
+            prev_run = runs[i - 1]
+            prev_clusters = prev_run.clusters.filter(cluster_type='group').prefetch_related('members')
+            prev_memberships = defaultdict(set)
+            
+            for cluster in prev_clusters:
+                for member in cluster.members.all():
+                    voter_key = f'{member.voter_type}:{member.voter_id}'
+                    prev_memberships[cluster.cluster_id].add(voter_key)
+            
+            # Calculate overlaps
+            for curr_cid, curr_voters in memberships.items():
+                for prev_cid, prev_voters in prev_memberships.items():
+                    overlap = len(curr_voters & prev_voters)
+                    if overlap >= min_overlap:
+                        predecessors_map[curr_cid].append({
+                            'run_id': prev_run.id,
+                            'cluster_id': prev_cid,
+                            'overlap': overlap,
+                        })
+        
+        # Compare with next run
+        successors_map = defaultdict(list)
+        if i < len(runs) - 1:
+            next_run = runs[i + 1]
+            next_clusters = next_run.clusters.filter(cluster_type='group').prefetch_related('members')
+            next_memberships = defaultdict(set)
+            
+            for cluster in next_clusters:
+                for member in cluster.members.all():
+                    voter_key = f'{member.voter_type}:{member.voter_id}'
+                    next_memberships[cluster.cluster_id].add(voter_key)
+            
+            # Calculate overlaps
+            for curr_cid, curr_voters in memberships.items():
+                for next_cid, next_voters in next_memberships.items():
+                    overlap = len(curr_voters & next_voters)
+                    if overlap >= min_overlap:
+                        successors_map[curr_cid].append({
+                            'run_id': next_run.id,
+                            'cluster_id': next_cid,
+                            'overlap': overlap,
+                        })
+        
+        # Build lineage entries
+        for cluster_id, voters in memberships.items():
+            predecessors = predecessors_map.get(cluster_id, [])
+            successors = successors_map.get(cluster_id, [])
+            
+            # Stability: ratio of largest successor overlap to cluster size
+            if successors:
+                max_successor_overlap = max(s['overlap'] for s in successors)
+                stability = max_successor_overlap / len(voters) if voters else 0
+            else:
+                stability = 0
+            
+            lineage.append({
+                'run_id': run.id,
+                'cluster_id': cluster_id,
+                'size': len(voters),
+                'predecessors': predecessors,
+                'successors': successors,
+                'stability': float(stability),
+            })
+    
+    return lineage
+
+
+def analyze_temporal_drift(run_current, run_past, noticia_ids=None):
+    """
+    Analyze if clusters changed their opinions on specific topics.
+    
+    Compares voting patterns between two runs to detect opinion drift.
+    
+    Args:
+        run_current: Recent VoterClusterRun
+        run_past: Earlier VoterClusterRun
+        noticia_ids: Optional list of noticia IDs to analyze (default: all common)
+    
+    Returns:
+        list of dict: [
+            {
+                'cluster_id': int,
+                'noticia_id': int,
+                'noticia': Noticia,
+                'opinion_past': 'buena'|'mala'|'neutral',
+                'opinion_current': 'buena'|'mala'|'neutral',
+                'changed': bool,
+                'drift_score': float,  # magnitude of change
+            }
+        ]
+    """
+    from core.models import Noticia
+    
+    # Get voting patterns for both runs
+    clusters_past = run_past.clusters.filter(cluster_type='group')
+    clusters_current = run_current.clusters.filter(cluster_type='group')
+    
+    # Match clusters between runs (by overlap)
+    stability = calculate_stability_index(run_past, run_current)
+    cluster_matches = {}  # past_id -> current_id
+    
+    for persistence in stability['cluster_persistence']:
+        if persistence['relationship'] in ['continuation', 'shuffle']:
+            cluster_matches[persistence['run1_cluster_id']] = persistence['run2_cluster_id']
+    
+    drift_results = []
+    
+    for past_id, current_id in cluster_matches.items():
+        cluster_past = clusters_past.filter(cluster_id=past_id).first()
+        cluster_current = clusters_current.filter(cluster_id=current_id).first()
+        
+        if not cluster_past or not cluster_current:
+            continue
+        
+        # Get voting patterns
+        patterns_past = {
+            p.noticia_id: p
+            for p in cluster_past.voting_patterns.all()
+        }
+        patterns_current = {
+            p.noticia_id: p
+            for p in cluster_current.voting_patterns.all()
+        }
+        
+        # Find common noticias
+        common_noticias = set(patterns_past.keys()) & set(patterns_current.keys())
+        
+        if noticia_ids:
+            common_noticias &= set(noticia_ids)
+        
+        for noticia_id in common_noticias:
+            past_pattern = patterns_past[noticia_id]
+            current_pattern = patterns_current[noticia_id]
+            
+            opinion_changed = past_pattern.majority_opinion != current_pattern.majority_opinion
+            
+            # Calculate drift magnitude (change in vote distribution)
+            # For simplicity, use difference in consensus scores
+            drift_score = abs(
+                current_pattern.consensus_score - past_pattern.consensus_score
+            )
+            
+            try:
+                noticia = Noticia.objects.get(id=noticia_id)
+            except Noticia.DoesNotExist:
+                continue
+            
+            if opinion_changed or drift_score > 0.2:  # Significant drift
+                drift_results.append({
+                    'cluster_id': current_id,
+                    'noticia_id': noticia_id,
+                    'noticia': noticia,
+                    'opinion_past': past_pattern.majority_opinion,
+                    'opinion_current': current_pattern.majority_opinion,
+                    'changed': opinion_changed,
+                    'drift_score': float(drift_score),
+                })
+    
+    # Sort by drift magnitude
+    drift_results.sort(key=lambda x: x['drift_score'], reverse=True)
+    
+    return drift_results
+
+
+def calculate_polarization_timeline(runs):
+    """
+    Calculate polarization metrics over time.
+    
+    Args:
+        runs: list of VoterClusterRun instances (ordered by time)
+    
+    Returns:
+        list of dict: [
+            {
+                'run_id': int,
+                'date': datetime,
+                'polarization_score': float,
+                'consensus_score': float,
+                'n_clusters': int,
+                'avg_cluster_size': float,
+                'silhouette_score': float,
+            }
+        ]
+    """
+    from core.clustering.consensus import calculate_polarization_score
+    
+    timeline = []
+    
+    for run in runs:
+        try:
+            polarization_data = calculate_polarization_score(run)
+            
+            clusters = run.clusters.filter(cluster_type='group')
+            avg_size = np.mean([c.size for c in clusters]) if clusters.exists() else 0
+            
+            timeline.append({
+                'run_id': run.id,
+                'date': run.created_at,
+                'polarization_score': polarization_data['polarization_score'],
+                'consensus_score': polarization_data['consensus_score'],
+                'n_clusters': run.n_clusters,
+                'avg_cluster_size': float(avg_size),
+                'silhouette_score': run.parameters.get('silhouette_score', 0),
+                'n_voters': run.n_voters,
+            })
+        except Exception as e:
+            logger.error(f"Error calculating metrics for run {run.id}: {e}")
+            continue
+    
+    return timeline
+
+
+def get_metrics_over_time(runs, metric='polarization'):
+    """
+    Extract a specific metric over time for plotting.
+    
+    Args:
+        runs: list of VoterClusterRun instances
+        metric: 'polarization'|'consensus'|'n_clusters'|'silhouette'
+    
+    Returns:
+        dict: {
+            'dates': [datetime, ...],
+            'values': [float, ...],
+        }
+    """
+    timeline = calculate_polarization_timeline(runs)
+    
+    metric_map = {
+        'polarization': 'polarization_score',
+        'consensus': 'consensus_score',
+        'n_clusters': 'n_clusters',
+        'silhouette': 'silhouette_score',
+        'avg_size': 'avg_cluster_size',
+    }
+    
+    metric_key = metric_map.get(metric, 'polarization_score')
+    
+    return {
+        'dates': [t['date'].isoformat() for t in timeline],
+        'values': [t[metric_key] for t in timeline],
+    }

--- a/core/templates/clustering/components/bridges_section.html
+++ b/core/templates/clustering/components/bridges_section.html
@@ -1,0 +1,274 @@
+<!-- Bridge-Builders Section -->
+<div class="mb-16">
+    <div class="mb-8">
+        <h2 class="text-3xl font-bold text-black mb-3 uppercase font-mono tracking-wide">
+            Los Puentes
+        </h2>
+        <p class="text-gray-700 font-mono text-sm">
+            Votantes que conectan diferentes burbujas de opinión.
+        </p>
+    </div>
+
+    {% if bridge_stats and bridge_stats.total_bridges > 0 %}
+    
+    <!-- Bridge Stats -->
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
+        <div class="border-2 border-black p-6 bg-white">
+            <div class="text-3xl font-bold text-black font-mono mb-2">
+                {{ bridge_stats.total_bridges }}
+            </div>
+            <div class="text-sm text-gray-700 font-mono">
+                puentes identificados
+            </div>
+        </div>
+        <div class="border-2 border-black p-6 bg-white">
+            <div class="text-3xl font-bold text-black font-mono mb-2">
+                {{ bridge_stats.avg_votes|floatformat:0 }}
+            </div>
+            <div class="text-sm text-gray-700 font-mono">
+                votos promedio por puente
+            </div>
+        </div>
+        <div class="border-2 border-black p-6 bg-white">
+            <div class="text-3xl font-bold text-black font-mono mb-2">
+                {{ bridge_stats.avg_connections|floatformat:1 }}
+            </div>
+            <div class="text-sm text-gray-700 font-mono">
+                burbujas conectadas por puente
+            </div>
+        </div>
+        <div class="border-2 border-black p-6 bg-white">
+            {% if bridge_stats.strongest_bridge %}
+            <div class="text-3xl font-bold text-black font-mono mb-2">
+                {{ bridge_stats.strongest_bridge.bridge_strength|floatformat:2 }}
+            </div>
+            <div class="text-sm text-gray-700 font-mono">
+                fuerza del puente más fuerte
+            </div>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- Network Visualization -->
+    <div class="border-2 border-black bg-white p-6 mb-8">
+        <h3 class="text-xl font-bold text-black mb-4 uppercase font-mono">
+            Red de Conexiones
+        </h3>
+        <p class="text-sm text-gray-700 font-mono mb-6">
+            Los puntos negros grandes son burbujas. Los puntos grises son votantes que actúan como puentes.
+        </p>
+        
+        <div id="bridges-network" style="height: 600px; width: 100%;"></div>
+        
+        <div class="mt-4 text-xs text-gray-600 font-mono">
+            Esta visualización se carga dinámicamente desde la API. Puede tardar unos segundos.
+        </div>
+    </div>
+
+    <!-- Top Bridges List -->
+    {% if top_bridges %}
+    <div class="border-2 border-black bg-white p-6">
+        <h3 class="text-xl font-bold text-black mb-4 uppercase font-mono">
+            Top Puentes por Fuerza de Conexión
+        </h3>
+        
+        <div class="overflow-x-auto">
+            <table class="w-full font-mono text-sm">
+                <thead>
+                    <tr class="border-b-2 border-black">
+                        <th class="text-left py-3 px-2 font-bold">#</th>
+                        <th class="text-left py-3 px-2 font-bold">Tipo</th>
+                        <th class="text-left py-3 px-2 font-bold">Burbuja Asignada</th>
+                        <th class="text-left py-3 px-2 font-bold">Conecta Burbujas</th>
+                        <th class="text-left py-3 px-2 font-bold">Fuerza</th>
+                        <th class="text-left py-3 px-2 font-bold">Votos</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for bridge in top_bridges %}
+                    {% if forloop.counter <= 15 %}
+                    <tr class="border-b border-gray-300 hover:bg-gray-50">
+                        <td class="py-3 px-2">{{ forloop.counter }}</td>
+                        <td class="py-3 px-2 uppercase text-xs">
+                            {{ bridge.voter_type }}
+                        </td>
+                        <td class="py-3 px-2 font-bold">
+                            B{{ bridge.assigned_cluster }}
+                        </td>
+                        <td class="py-3 px-2">
+                            {% for cid in bridge.connected_clusters %}
+                            <span class="inline-block bg-gray-200 px-2 py-1 text-xs mr-1 mb-1">
+                                B{{ cid }}
+                            </span>
+                            {% endfor %}
+                        </td>
+                        <td class="py-3 px-2">
+                            <div class="flex items-center gap-2">
+                                <div class="w-16 bg-gray-200 h-3 border border-gray-400">
+                                    <div class="bg-black h-full" 
+                                         style="width: {{ bridge.bridge_strength|floatformat:0 }}%"></div>
+                                </div>
+                                <span class="text-xs">{{ bridge.bridge_strength|floatformat:2 }}</span>
+                            </div>
+                        </td>
+                        <td class="py-3 px-2">
+                            {{ bridge.n_votes }}
+                        </td>
+                    </tr>
+                    {% endif %}
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- What makes a bridge? -->
+    <div class="mt-8 bg-gray-50 border-2 border-black p-6">
+        <h3 class="text-sm uppercase font-bold text-black font-mono mb-3 tracking-wide">
+            ¿Qué es un puente?
+        </h3>
+        <p class="text-gray-800 font-mono text-sm leading-relaxed mb-3">
+            Un votante es identificado como "puente" cuando sus patrones de votación lo posicionan 
+            cerca de los centroides de múltiples burbujas. Esto indica que comparten opiniones 
+            con diferentes grupos, conectando perspectivas diversas.
+        </p>
+        <p class="text-gray-800 font-mono text-sm leading-relaxed">
+            Los puentes son importantes porque demuestran que no estamos completamente fragmentados. 
+            Hay personas que naturalmente mantienen opiniones que resuenan con diferentes burbujas, 
+            actuando como conectores en el panorama de opinión.
+        </p>
+    </div>
+
+    {% else %}
+    <div class="border-2 border-black p-8 bg-gray-50">
+        <p class="text-gray-700 font-mono text-center">
+            No hay datos de puentes disponibles
+        </p>
+    </div>
+    {% endif %}
+</div>
+
+<!-- Load D3.js for network visualization -->
+<script src="https://d3js.org/d3.v7.min.js"></script>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Fetch bridge network data from API
+    fetch('/api/clustering/bridges/?format=network&limit=50')
+        .then(response => response.json())
+        .then(data => {
+            if (data.network) {
+                renderBridgeNetwork(data.network);
+            }
+        })
+        .catch(error => {
+            console.error('Error loading bridge network:', error);
+            document.getElementById('bridges-network').innerHTML = 
+                '<div class="text-center text-gray-600 font-mono text-sm py-20">Error cargando red de puentes</div>';
+        });
+});
+
+function renderBridgeNetwork(networkData) {
+    const container = document.getElementById('bridges-network');
+    const width = container.clientWidth;
+    const height = 600;
+    
+    // Clear existing
+    container.innerHTML = '';
+    
+    // Create SVG
+    const svg = d3.select('#bridges-network')
+        .append('svg')
+        .attr('width', width)
+        .attr('height', height);
+    
+    // Create force simulation
+    const simulation = d3.forceSimulation(networkData.nodes)
+        .force('link', d3.forceLink(networkData.edges)
+            .id(d => d.id)
+            .distance(d => 100))
+        .force('charge', d3.forceManyBody().strength(-200))
+        .force('center', d3.forceCenter(width / 2, height / 2))
+        .force('collision', d3.forceCollide().radius(d => d.type === 'cluster' ? 40 : 10));
+    
+    // Draw edges
+    const link = svg.append('g')
+        .selectAll('line')
+        .data(networkData.edges)
+        .join('line')
+        .attr('stroke', '#999')
+        .attr('stroke-opacity', d => d.weight * 0.6)
+        .attr('stroke-width', d => d.weight * 2);
+    
+    // Draw nodes
+    const node = svg.append('g')
+        .selectAll('circle')
+        .data(networkData.nodes)
+        .join('circle')
+        .attr('r', d => d.type === 'cluster' ? 20 : 5)
+        .attr('fill', d => d.type === 'cluster' ? '#000000' : '#999999')
+        .attr('stroke', '#fff')
+        .attr('stroke-width', 2)
+        .call(d3.drag()
+            .on('start', dragstarted)
+            .on('drag', dragged)
+            .on('end', dragended));
+    
+    // Add labels for clusters
+    const label = svg.append('g')
+        .selectAll('text')
+        .data(networkData.nodes.filter(d => d.type === 'cluster'))
+        .join('text')
+        .text(d => d.label)
+        .attr('font-size', 10)
+        .attr('font-family', 'IBM Plex Mono, monospace')
+        .attr('text-anchor', 'middle')
+        .attr('dy', -25);
+    
+    // Tooltips
+    node.append('title')
+        .text(d => {
+            if (d.type === 'cluster') {
+                return `${d.label}\nTamaño: ${d.size}`;
+            } else {
+                return `Puente\nFuerza: ${d.strength.toFixed(2)}\nVotos: ${d.n_votes}`;
+            }
+        });
+    
+    // Update positions on tick
+    simulation.on('tick', () => {
+        link
+            .attr('x1', d => d.source.x)
+            .attr('y1', d => d.source.y)
+            .attr('x2', d => d.target.x)
+            .attr('y2', d => d.target.y);
+        
+        node
+            .attr('cx', d => d.x)
+            .attr('cy', d => d.y);
+        
+        label
+            .attr('x', d => d.x)
+            .attr('y', d => d.y);
+    });
+    
+    // Drag functions
+    function dragstarted(event, d) {
+        if (!event.active) simulation.alphaTarget(0.3).restart();
+        d.fx = d.x;
+        d.fy = d.y;
+    }
+    
+    function dragged(event, d) {
+        d.fx = event.x;
+        d.fy = event.y;
+    }
+    
+    function dragended(event, d) {
+        if (!event.active) simulation.alphaTarget(0);
+        d.fx = null;
+        d.fy = null;
+    }
+}
+</script>

--- a/core/templates/clustering/components/bubble_details.html
+++ b/core/templates/clustering/components/bubble_details.html
@@ -1,0 +1,194 @@
+<!-- Bubble Details Section -->
+<div class="mb-16">
+    <div class="mb-8">
+        <h2 class="text-3xl font-bold text-black mb-3 uppercase font-mono tracking-wide">
+            Análisis por Burbuja
+        </h2>
+        <p class="text-gray-700 font-mono text-sm">
+            Perfil detallado de cada burbuja de opinión.
+        </p>
+    </div>
+
+    {% if cluster_run %}
+    {% for cluster in cluster_run.clusters.all %}
+    {% if cluster.cluster_type == 'group' %}
+    
+    <div class="mb-8 border-2 border-black bg-white overflow-hidden" id="bubble-{{ cluster.cluster_id }}">
+        <!-- Header -->
+        <div class="bg-black px-6 py-4">
+            <div class="flex justify-between items-center">
+                <div>
+                    <h3 class="text-2xl font-bold text-white font-mono">
+                        {% if cluster.llm_name %}
+                            {{ cluster.llm_name }}
+                        {% else %}
+                            Burbuja {{ cluster.cluster_id }}
+                        {% endif %}
+                    </h3>
+                    {% if cluster.llm_description %}
+                    <p class="text-gray-300 text-sm font-mono mt-1">
+                        {{ cluster.llm_description }}
+                    </p>
+                    {% endif %}
+                </div>
+                <div class="text-white text-sm font-mono">
+                    {{ cluster.size }} votantes
+                </div>
+            </div>
+        </div>
+
+        <!-- Stats Grid -->
+        <div class="p-6">
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+                <div>
+                    <div class="text-sm text-gray-600 font-mono uppercase">Tamaño</div>
+                    <div class="text-2xl font-bold text-black font-mono">
+                        {{ cluster.size }} votantes
+                    </div>
+                    <div class="text-xs text-gray-500 font-mono">
+                        {{ cluster.size|floatformat:0 }}% del total
+                    </div>
+                </div>
+                <div>
+                    <div class="text-sm text-gray-600 font-mono uppercase">Consenso Interno</div>
+                    <div class="text-2xl font-bold font-mono
+                        {% if cluster.consensus_score >= 0.7 %}text-green-600
+                        {% elif cluster.consensus_score >= 0.5 %}text-yellow-600
+                        {% else %}text-red-600{% endif %}">
+                        {% if cluster.consensus_score %}
+                        {{ cluster.consensus_score|floatformat:2 }}
+                        {% else %}
+                        N/A
+                        {% endif %}
+                    </div>
+                    <div class="text-xs text-gray-500 font-mono">
+                        {% if cluster.consensus_score %}
+                            {% if cluster.consensus_score >= 0.7 %}
+                                Alta cohesión interna
+                            {% elif cluster.consensus_score >= 0.5 %}
+                                Cohesión moderada
+                            {% else %}
+                                Baja cohesión interna
+                            {% endif %}
+                        {% else %}
+                            Sin datos
+                        {% endif %}
+                    </div>
+                </div>
+                <div>
+                    <div class="text-sm text-gray-600 font-mono uppercase">Centroide</div>
+                    <div class="text-sm font-mono text-gray-900 font-bold">
+                        ({{ cluster.centroid_x|floatformat:2 }}, {{ cluster.centroid_y|floatformat:2 }})
+                    </div>
+                    <div class="text-xs text-gray-500 font-mono">
+                        Posición en el mapa
+                    </div>
+                </div>
+            </div>
+
+            <!-- Entities Section -->
+            {% if cluster.top_entities_positive or cluster.top_entities_negative %}
+            <div class="mb-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+                {% if cluster.top_entities_positive %}
+                <div class="bg-gray-50 border border-gray-300 p-4">
+                    <h4 class="text-sm font-semibold text-gray-900 font-mono mb-3 uppercase">
+                        Ven Positivamente
+                    </h4>
+                    <div class="flex flex-wrap gap-2">
+                        {% for entity in cluster.top_entities_positive %}
+                        <span class="inline-flex items-center px-3 py-1 border border-gray-400 text-xs font-mono bg-white">
+                            {{ entity.nombre }}
+                            <span class="ml-1 text-gray-600">({{ entity.count }})</span>
+                        </span>
+                        {% endfor %}
+                    </div>
+                </div>
+                {% endif %}
+                
+                {% if cluster.top_entities_negative %}
+                <div class="bg-gray-50 border border-gray-300 p-4">
+                    <h4 class="text-sm font-semibold text-gray-900 font-mono mb-3 uppercase">
+                        Ven Negativamente
+                    </h4>
+                    <div class="flex flex-wrap gap-2">
+                        {% for entity in cluster.top_entities_negative %}
+                        <span class="inline-flex items-center px-3 py-1 border border-gray-400 text-xs font-mono bg-white">
+                            {{ entity.nombre }}
+                            <span class="ml-1 text-gray-600">({{ entity.count }})</span>
+                        </span>
+                        {% endfor %}
+                    </div>
+                </div>
+                {% endif %}
+            </div>
+            {% endif %}
+
+            <!-- Top News Patterns -->
+            {% with patterns=cluster.voting_patterns.all|slice:":5" %}
+            {% if patterns %}
+            <div>
+                <h4 class="text-sm font-semibold text-gray-900 font-mono mb-3 uppercase">
+                    Noticias con Mayor Consenso en esta Burbuja
+                </h4>
+                <div class="space-y-2">
+                    {% for pattern in patterns %}
+                    <div class="flex items-center justify-between p-3 bg-gray-50 border border-gray-300 hover:bg-gray-100 transition-colors">
+                        <div class="flex-1">
+                            <a href="{% url 'noticia-detail' pattern.noticia.slug %}"
+                               class="text-sm font-medium text-black font-mono hover:underline">
+                                {{ pattern.noticia.mostrar_titulo|truncatewords:15 }}
+                            </a>
+                            <div class="flex gap-3 mt-1 text-xs text-gray-600 font-mono">
+                                <span class="{% if pattern.majority_opinion == 'buena' %}text-black font-bold{% endif %}">
+                                    {{ pattern.count_buena }} buena
+                                </span>
+                                <span class="{% if pattern.majority_opinion == 'mala' %}text-black font-bold{% endif %}">
+                                    {{ pattern.count_mala }} mala
+                                </span>
+                                <span class="{% if pattern.majority_opinion == 'neutral' %}text-black font-bold{% endif %}">
+                                    {{ pattern.count_neutral }} neutral
+                                </span>
+                            </div>
+                        </div>
+                        <div class="ml-4 text-right">
+                            <div class="text-sm font-bold font-mono
+                                {% if pattern.majority_opinion == 'buena' %}text-green-700
+                                {% elif pattern.majority_opinion == 'mala' %}text-red-700
+                                {% else %}text-gray-700{% endif %}">
+                                {{ pattern.majority_opinion|upper }}
+                            </div>
+                            <div class="text-xs text-gray-500 font-mono">
+                                {{ pattern.consensus_score|floatformat:2 }} consenso
+                            </div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+            {% else %}
+            <div class="text-sm text-gray-500 text-center py-4 font-mono">
+                No hay patrones de votación disponibles para esta burbuja
+            </div>
+            {% endif %}
+            {% endwith %}
+
+            <!-- Actions -->
+            <div class="mt-6 pt-6 border-t border-gray-300">
+                <a href="{% url 'mapa' %}?cluster={{ cluster.cluster_id }}" 
+                   class="inline-block px-4 py-2 bg-black text-white font-mono text-sm uppercase hover:bg-gray-800 transition-colors">
+                    Ver en el Mapa
+                </a>
+            </div>
+        </div>
+    </div>
+    
+    {% endif %}
+    {% endfor %}
+    {% else %}
+    <div class="border-2 border-black p-8 bg-gray-50">
+        <p class="text-gray-700 font-mono text-center">
+            No hay datos de burbujas disponibles
+        </p>
+    </div>
+    {% endif %}
+</div>

--- a/core/templates/clustering/components/consensus_section.html
+++ b/core/templates/clustering/components/consensus_section.html
@@ -1,0 +1,194 @@
+<!-- Consensus Section -->
+<div class="mb-16">
+    <div class="mb-8">
+        <h2 class="text-3xl font-bold text-black mb-3 uppercase font-mono tracking-wide">
+            Consenso Oculto
+        </h2>
+        <p class="text-gray-700 font-mono text-sm">
+            Noticias donde todas las burbujas coinciden. El acuerdo que no vemos.
+        </p>
+    </div>
+
+    {% if consensus_news %}
+    <!-- Consensus Carousel -->
+    <div class="relative mb-8">
+        <div class="overflow-x-auto pb-6 scrollbar-hide" id="consensus-carousel">
+            <div class="flex gap-6" style="width: fit-content;">
+                {% for item in consensus_news %}
+                <div class="border-2 border-black bg-white flex-shrink-0" style="width: 400px;">
+                    <!-- Image if available -->
+                    {% if item.noticia.mostrar_imagen %}
+                    <div class="h-48 bg-gray-200 overflow-hidden">
+                        <img src="{{ item.noticia.mostrar_imagen }}" 
+                             alt="{{ item.noticia.mostrar_titulo }}"
+                             class="w-full h-full object-cover grayscale">
+                    </div>
+                    {% endif %}
+                    
+                    <!-- Content -->
+                    <div class="p-6">
+                        <!-- Consensus Badge -->
+                        <div class="mb-4">
+                            <div class="inline-block bg-black text-white px-3 py-1 text-xs font-mono uppercase">
+                                {{ item.consensus_score|floatformat:0 }}% consenso
+                            </div>
+                        </div>
+
+                        <!-- Title -->
+                        <h3 class="text-lg font-bold text-black font-mono mb-3 leading-tight">
+                            <a href="{% url 'noticia-detail' item.noticia.slug %}" 
+                               class="hover:underline">
+                                {{ item.noticia.mostrar_titulo|truncatewords:15 }}
+                            </a>
+                        </h3>
+
+                        <!-- Majority Opinion -->
+                        <div class="mb-4 text-sm font-mono">
+                            <span class="text-gray-600">Opinión mayoritaria:</span>
+                            <span class="font-bold text-black uppercase">
+                                {{ item.majority_opinion }}
+                            </span>
+                        </div>
+
+                        <!-- Cluster Agreement Mini-Viz -->
+                        <div class="space-y-2">
+                            <div class="text-xs uppercase text-gray-600 font-mono">
+                                Acuerdo por burbuja:
+                            </div>
+                            {% for cluster_id, votes in item.cluster_votes.items %}
+                            <div class="flex items-center gap-2">
+                                <div class="text-xs font-mono text-gray-700 w-16">
+                                    B{{ cluster_id }}
+                                </div>
+                                <div class="flex-1 bg-gray-200 h-4 border border-gray-400">
+                                    {% if item.majority_opinion == 'buena' %}
+                                    <div class="bg-black h-full" style="width: {{ votes.buena|floatformat:0 }}%"></div>
+                                    {% elif item.majority_opinion == 'mala' %}
+                                    <div class="bg-black h-full" style="width: {{ votes.mala|floatformat:0 }}%"></div>
+                                    {% else %}
+                                    <div class="bg-black h-full" style="width: {{ votes.neutral|floatformat:0 }}%"></div>
+                                    {% endif %}
+                                </div>
+                                <div class="text-xs font-mono text-gray-700 w-12 text-right">
+                                    {% if item.majority_opinion == 'buena' %}
+                                    {{ votes.buena|floatformat:0 }}%
+                                    {% elif item.majority_opinion == 'mala' %}
+                                    {{ votes.mala|floatformat:0 }}%
+                                    {% else %}
+                                    {{ votes.neutral|floatformat:0 }}%
+                                    {% endif %}
+                                </div>
+                            </div>
+                            {% endfor %}
+                        </div>
+
+                        <!-- Read Link -->
+                        <div class="mt-4 pt-4 border-t border-gray-300">
+                            <a href="{{ item.noticia.enlace }}" 
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-xs uppercase font-mono text-black hover:underline">
+                                Leer artículo →
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+
+        <!-- Scroll Hint -->
+        <div class="text-center text-xs uppercase font-mono text-gray-500 mt-2">
+            ← Desliza para ver más →
+        </div>
+    </div>
+
+    <!-- Stats Summary -->
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-8">
+        <div class="border-2 border-black p-6 bg-white">
+            <div class="text-3xl font-bold text-black font-mono mb-2">
+                {{ consensus_news|length }}
+            </div>
+            <div class="text-sm text-gray-700 font-mono">
+                noticias con alto consenso mostradas
+            </div>
+        </div>
+        <div class="border-2 border-black p-6 bg-white">
+            <div class="text-3xl font-bold text-black font-mono mb-2">
+                {% if consensus_news %}
+                {{ consensus_news.0.consensus_score|floatformat:0 }}%
+                {% else %}
+                0%
+                {% endif %}
+            </div>
+            <div class="text-sm text-gray-700 font-mono">
+                consenso más alto encontrado
+            </div>
+        </div>
+        <div class="border-2 border-black p-6 bg-white">
+            <div class="text-3xl font-bold text-black font-mono mb-2">
+                {{ cluster_run.n_clusters }}
+            </div>
+            <div class="text-sm text-gray-700 font-mono">
+                burbujas analizadas
+            </div>
+        </div>
+    </div>
+
+    {% else %}
+    <div class="border-2 border-black p-8 bg-gray-50">
+        <p class="text-gray-700 font-mono text-center">
+            No hay datos de consenso disponibles
+        </p>
+    </div>
+    {% endif %}
+</div>
+
+<style>
+.scrollbar-hide::-webkit-scrollbar {
+    display: none;
+}
+.scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+}
+</style>
+
+<script>
+// Smooth horizontal scroll for carousel
+document.addEventListener('DOMContentLoaded', function() {
+    const carousel = document.getElementById('consensus-carousel');
+    if (carousel) {
+        let isDown = false;
+        let startX;
+        let scrollLeft;
+
+        carousel.addEventListener('mousedown', (e) => {
+            isDown = true;
+            carousel.style.cursor = 'grabbing';
+            startX = e.pageX - carousel.offsetLeft;
+            scrollLeft = carousel.scrollLeft;
+        });
+
+        carousel.addEventListener('mouseleave', () => {
+            isDown = false;
+            carousel.style.cursor = 'grab';
+        });
+
+        carousel.addEventListener('mouseup', () => {
+            isDown = false;
+            carousel.style.cursor = 'grab';
+        });
+
+        carousel.addEventListener('mousemove', (e) => {
+            if (!isDown) return;
+            e.preventDefault();
+            const x = e.pageX - carousel.offsetLeft;
+            const walk = (x - startX) * 2;
+            carousel.scrollLeft = scrollLeft - walk;
+        });
+
+        carousel.style.cursor = 'grab';
+    }
+});
+</script>

--- a/core/templates/clustering/components/divisive_section.html
+++ b/core/templates/clustering/components/divisive_section.html
@@ -1,0 +1,181 @@
+<!-- Divisive Section -->
+<div class="mb-16">
+    <div class="mb-8">
+        <h2 class="text-3xl font-bold text-black mb-3 uppercase font-mono tracking-wide">
+            Lo que nos Divide
+        </h2>
+        <p class="text-gray-700 font-mono text-sm">
+            Las pocas noticias que realmente polarizan a las burbujas.
+        </p>
+    </div>
+
+    {% if divisive_news %}
+    <!-- Divisive News List -->
+    <div class="space-y-4 mb-8">
+        {% for item in divisive_news %}
+        <div class="border-2 border-black bg-white p-6 hover:bg-gray-50 transition-colors">
+            <div class="flex justify-between items-start gap-6">
+                <!-- Content -->
+                <div class="flex-1">
+                    <!-- Polarization Badge -->
+                    <div class="mb-3">
+                        <span class="inline-block bg-black text-white px-3 py-1 text-xs font-mono uppercase">
+                            Polarización: {{ item.polarization_score|floatformat:2 }}
+                        </span>
+                    </div>
+
+                    <!-- Title -->
+                    <h3 class="text-xl font-bold text-black font-mono mb-3">
+                        <a href="{% url 'noticia-detail' item.noticia.slug %}" 
+                           class="hover:underline">
+                            {{ item.noticia.mostrar_titulo }}
+                        </a>
+                    </h3>
+
+                    <!-- Cluster Disagreement -->
+                    <div class="mb-4">
+                        <div class="text-xs uppercase text-gray-600 font-mono mb-2">
+                            Cómo vota cada burbuja:
+                        </div>
+                        <div class="flex flex-wrap gap-3">
+                            {% for cluster_id, votes in item.cluster_votes.items %}
+                            <div class="text-xs font-mono border border-gray-300 p-2">
+                                <div class="font-bold mb-1">Burbuja {{ cluster_id }}</div>
+                                <div class="space-y-1">
+                                    <div class="flex gap-2">
+                                        <span class="text-green-700">Buena:</span>
+                                        <span class="font-bold">{{ votes.buena|floatformat:0 }}%</span>
+                                    </div>
+                                    <div class="flex gap-2">
+                                        <span class="text-red-700">Mala:</span>
+                                        <span class="font-bold">{{ votes.mala|floatformat:0 }}%</span>
+                                    </div>
+                                    <div class="flex gap-2">
+                                        <span class="text-gray-600">Neutral:</span>
+                                        <span class="font-bold">{{ votes.neutral|floatformat:0 }}%</span>
+                                    </div>
+                                </div>
+                            </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+
+                    <!-- Link -->
+                    <a href="{{ item.noticia.enlace }}" 
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="text-xs uppercase font-mono text-black hover:underline">
+                        Leer artículo →
+                    </a>
+                </div>
+
+                <!-- Visual indicator -->
+                <div class="w-24 flex-shrink-0">
+                    <div class="h-24 border-2 border-black relative overflow-hidden">
+                        <!-- Simple bar showing polarization -->
+                        <div class="absolute inset-0 flex">
+                            {% for cluster_id, votes in item.cluster_votes.items %}
+                            {% if votes.buena > votes.mala %}
+                            <div class="bg-gray-200" style="width: calc(100% / {{ item.cluster_votes|length }})"></div>
+                            {% else %}
+                            <div class="bg-black" style="width: calc(100% / {{ item.cluster_votes|length }})"></div>
+                            {% endif %}
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="text-xs text-center font-mono text-gray-600 mt-1">
+                        División visual
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+
+    <!-- Polarization Timeline -->
+    {% if polarization_timeline %}
+    <div class="border-2 border-black bg-white p-6 mt-8">
+        <h3 class="text-xl font-bold text-black mb-4 uppercase font-mono">
+            Evolución de la Polarización
+        </h3>
+        <p class="text-sm text-gray-700 font-mono mb-6">
+            ¿La sociedad uruguaya se polariza más o menos con el tiempo?
+        </p>
+        
+        <div id="polarization-timeline-chart" style="height: 400px;"></div>
+    </div>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const timelineData = {{ polarization_timeline|safe }};
+        
+        if (timelineData && timelineData.length > 0) {
+            // Extract dates and metrics
+            const dates = timelineData.map(d => d.date);
+            const polarization = timelineData.map(d => d.polarization_score);
+            const consensus = timelineData.map(d => d.consensus_score);
+            
+            const traces = [
+                {
+                    x: dates,
+                    y: polarization,
+                    type: 'scatter',
+                    mode: 'lines+markers',
+                    name: 'Polarización',
+                    line: { color: '#000000', width: 3 },
+                    marker: { size: 8, color: '#000000' },
+                },
+                {
+                    x: dates,
+                    y: consensus,
+                    type: 'scatter',
+                    mode: 'lines+markers',
+                    name: 'Consenso',
+                    line: { color: '#666666', width: 3, dash: 'dash' },
+                    marker: { size: 8, color: '#666666' },
+                }
+            ];
+            
+            const layout = {
+                xaxis: {
+                    title: 'Fecha',
+                    type: 'date',
+                },
+                yaxis: {
+                    title: 'Score (0-1)',
+                    range: [0, 1],
+                },
+                hovermode: 'x unified',
+                showlegend: true,
+                legend: {
+                    x: 0,
+                    y: 1,
+                },
+                margin: { l: 60, r: 30, t: 30, b: 60 },
+                font: {
+                    family: 'IBM Plex Mono, monospace',
+                    size: 12,
+                },
+                plot_bgcolor: '#FFFFFF',
+                paper_bgcolor: '#FFFFFF',
+            };
+            
+            const config = {
+                responsive: true,
+                displayModeBar: false,
+            };
+            
+            Plotly.newPlot('polarization-timeline-chart', traces, layout, config);
+        }
+    });
+    </script>
+    {% endif %}
+
+    {% else %}
+    <div class="border-2 border-black p-8 bg-gray-50">
+        <p class="text-gray-700 font-mono text-center">
+            No hay datos de polarización disponibles
+        </p>
+    </div>
+    {% endif %}
+</div>

--- a/core/templates/clustering/components/evolution_section.html
+++ b/core/templates/clustering/components/evolution_section.html
@@ -1,0 +1,230 @@
+<!-- Evolution Section -->
+<div class="mb-16">
+    <div class="mb-8">
+        <h2 class="text-3xl font-bold text-black mb-3 uppercase font-mono tracking-wide">
+            Evolución Temporal
+        </h2>
+        <p class="text-gray-700 font-mono text-sm">
+            Cómo las burbujas de opinión cambian y evolucionan con el tiempo.
+        </p>
+    </div>
+
+    <!-- Sankey Diagram (from existing stats page) -->
+    <div class="border-2 border-black bg-white p-6 mb-8">
+        <div class="mb-4">
+            <h3 class="text-xl font-bold text-black uppercase font-mono">
+                Evolución de Burbujas
+            </h3>
+            <p class="text-sm text-gray-600 font-mono mt-1">
+                Cómo se dividen, fusionan y evolucionan las burbujas a lo largo del tiempo
+            </p>
+        </div>
+        
+        <!-- Controls -->
+        <div class="flex flex-wrap gap-4 mb-4 items-center">
+            <div class="flex items-center gap-2">
+                <label for="runs-select" class="text-sm font-medium text-gray-700 font-mono">Corridas:</label>
+                <select id="runs-select" 
+                        class="border border-gray-300 px-3 py-1 text-sm font-mono focus:ring-2 focus:ring-black">
+                    <option value="3">3</option>
+                    <option value="5" selected>5</option>
+                    <option value="7">7</option>
+                    <option value="10">10</option>
+                </select>
+            </div>
+            <div class="flex items-center gap-2">
+                <label for="mode-select" class="text-sm font-medium text-gray-700 font-mono">Modo:</label>
+                <select id="mode-select" 
+                        class="border border-gray-300 px-3 py-1 text-sm font-mono focus:ring-2 focus:ring-black">
+                    <option value="spread" selected>Distribuidas en el tiempo</option>
+                    <option value="recent">Últimas consecutivas</option>
+                </select>
+            </div>
+        </div>
+
+        <!-- Loading State -->
+        <div id="evolution-loading" class="text-center py-12">
+            <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-black"></div>
+            <p class="text-gray-600 font-mono mt-2">Cargando evolución de burbujas...</p>
+        </div>
+
+        <!-- Chart -->
+        <div id="evolution-chart" class="hidden" style="height: 600px;"></div>
+
+        <!-- Error State -->
+        <div id="evolution-error" class="hidden bg-red-50 border border-red-200 p-4 text-center">
+            <p class="text-red-800 font-medium font-mono">Error al cargar datos de evolución</p>
+            <p class="text-red-600 text-sm font-mono mt-1" id="evolution-error-message"></p>
+        </div>
+
+        <!-- Legend -->
+        <div class="mt-4 p-4 bg-gray-50 border border-gray-300">
+            <div class="text-sm font-semibold text-gray-700 font-mono mb-2">Leyenda:</div>
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm font-mono">
+                <div class="flex items-center gap-2">
+                    <div class="w-12 h-3 rounded" style="background: rgba(0, 200, 0, 0.4);"></div>
+                    <span class="text-gray-700">Continuación (&gt;80%)</span>
+                </div>
+                <div class="flex items-center gap-2">
+                    <div class="w-12 h-3 rounded" style="background: rgba(255, 165, 0, 0.4);"></div>
+                    <span class="text-gray-700">División (split)</span>
+                </div>
+                <div class="flex items-center gap-2">
+                    <div class="w-12 h-3 rounded" style="background: rgba(0, 100, 255, 0.4);"></div>
+                    <span class="text-gray-700">Fusión (merge)</span>
+                </div>
+                <div class="flex items-center gap-2">
+                    <div class="w-12 h-3 rounded" style="background: rgba(100, 100, 100, 0.2);"></div>
+                    <span class="text-gray-700">Migración menor</span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Stability Metrics -->
+    <div class="border-2 border-black bg-white p-6 mb-8">
+        <h3 class="text-xl font-bold text-black mb-4 uppercase font-mono">
+            Índice de Estabilidad
+        </h3>
+        <p class="text-sm text-gray-700 font-mono mb-6">
+            ¿Qué tan estables son las burbujas entre corridas consecutivas?
+        </p>
+        
+        <div id="stability-chart" style="height: 400px;"></div>
+        
+        <div id="stability-loading" class="text-center py-12">
+            <div class="inline-block animate-spin rounded-full h-6 w-6 border-b-2 border-black"></div>
+            <p class="text-gray-600 font-mono text-sm mt-2">Cargando datos de estabilidad...</p>
+        </div>
+    </div>
+
+    <!-- Interpretation -->
+    <div class="bg-gray-50 border-2 border-black p-6">
+        <h3 class="text-sm uppercase font-bold text-black font-mono mb-3 tracking-wide">
+            Interpretación
+        </h3>
+        <p class="text-gray-800 font-mono text-sm leading-relaxed mb-3">
+            La evolución de burbujas revela cómo los patrones de opinión cambian con el tiempo. 
+            Las burbujas pueden:
+        </p>
+        <ul class="list-disc list-inside text-gray-800 font-mono text-sm space-y-2 mb-3 ml-4">
+            <li><strong>Continuar</strong>: Mantener su composición (~80%+ de votantes permanecen)</li>
+            <li><strong>Dividirse</strong>: Fracturarse en múltiples burbujas más pequeñas</li>
+            <li><strong>Fusionarse</strong>: Unirse con otras burbujas para formar grupos más grandes</li>
+            <li><strong>Migrar</strong>: Votantes cambian de burbuja por cambios en sus opiniones</li>
+        </ul>
+        <p class="text-gray-800 font-mono text-sm leading-relaxed">
+            Un índice de estabilidad alto indica que las burbujas son consistentes en el tiempo. 
+            Un índice bajo sugiere que la opinión pública está en flujo activo.
+        </p>
+    </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Load cluster evolution data
+    loadEvolution();
+    
+    // Load stability data
+    loadStability();
+    
+    // Listen for control changes
+    document.getElementById('runs-select').addEventListener('change', loadEvolution);
+    document.getElementById('mode-select').addEventListener('change', loadEvolution);
+});
+
+function loadEvolution() {
+    const runs = parseInt(document.getElementById('runs-select').value);
+    const mode = document.getElementById('mode-select').value;
+    const loading = document.getElementById('evolution-loading');
+    const chart = document.getElementById('evolution-chart');
+    const error = document.getElementById('evolution-error');
+    
+    // Show loading state
+    loading.classList.remove('hidden');
+    chart.classList.add('hidden');
+    error.classList.add('hidden');
+    
+    fetch(`/api/clustering/evolution/?runs=${runs}&mode=${mode}`)
+        .then(response => {
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+            }
+            return response.json();
+        })
+        .then(data => {
+            // Hide loading, show chart
+            loading.classList.add('hidden');
+            chart.classList.remove('hidden');
+            
+            // Render Sankey diagram
+            Plotly.newPlot('evolution-chart', data.data, data.layout, {
+                responsive: true,
+                displayModeBar: true,
+                modeBarButtonsToRemove: ['lasso2d', 'select2d'],
+            });
+        })
+        .catch(err => {
+            console.error('Error loading evolution data:', err);
+            loading.classList.add('hidden');
+            error.classList.remove('hidden');
+            document.getElementById('evolution-error-message').textContent = err.message;
+        });
+}
+
+function loadStability() {
+    const loading = document.getElementById('stability-loading');
+    const chart = document.getElementById('stability-chart');
+    
+    fetch('/api/clustering/stability/?runs=10')
+        .then(response => response.json())
+        .then(data => {
+            loading.classList.add('hidden');
+            
+            if (data.comparisons && data.comparisons.length > 0) {
+                // Extract data
+                const labels = data.comparisons.map((c, i) => `Run ${i+1}→${i+2}`);
+                const stability = data.comparisons.map(c => c.stability_score);
+                
+                const trace = {
+                    x: labels,
+                    y: stability,
+                    type: 'bar',
+                    marker: {
+                        color: stability.map(s => s > 0.8 ? '#000000' : s > 0.5 ? '#666666' : '#999999'),
+                    },
+                };
+                
+                const layout = {
+                    xaxis: {
+                        title: 'Comparación entre corridas',
+                    },
+                    yaxis: {
+                        title: 'Índice de Estabilidad (0-1)',
+                        range: [0, 1],
+                    },
+                    showlegend: false,
+                    margin: { l: 60, r: 30, t: 30, b: 80 },
+                    font: {
+                        family: 'IBM Plex Mono, monospace',
+                        size: 12,
+                    },
+                    plot_bgcolor: '#FFFFFF',
+                    paper_bgcolor: '#FFFFFF',
+                };
+                
+                Plotly.newPlot('stability-chart', [trace], layout, {
+                    responsive: true,
+                    displayModeBar: false,
+                });
+            } else {
+                chart.innerHTML = '<div class="text-center text-gray-600 font-mono text-sm py-12">No hay suficientes corridas para calcular estabilidad</div>';
+            }
+        })
+        .catch(err => {
+            console.error('Error loading stability data:', err);
+            loading.classList.add('hidden');
+            chart.innerHTML = '<div class="text-center text-gray-600 font-mono text-sm py-12">Error cargando datos de estabilidad</div>';
+        });
+}
+</script>

--- a/core/templates/clustering/components/executive_summary.html
+++ b/core/templates/clustering/components/executive_summary.html
@@ -1,0 +1,85 @@
+<!-- Executive Summary Section -->
+<div class="mb-16 border-2 border-black p-8 bg-white">
+    <h2 class="text-3xl font-bold text-black mb-6 uppercase font-mono tracking-wide">
+        Resumen Ejecutivo
+    </h2>
+    
+    <div class="space-y-6">
+        <!-- Key Insight 1: Consensus -->
+        <div class="border-l-4 border-black pl-6">
+            <div class="text-5xl font-bold text-black font-mono mb-2">
+                {{ executive_summary.consensus_pct }}%
+            </div>
+            <p class="text-lg text-gray-800 font-mono">
+                de consenso promedio entre todas las burbujas
+            </p>
+            <p class="text-sm text-gray-600 font-mono mt-2">
+                {{ executive_summary.n_consensus_news }} noticias generan acuerdo cross-cluster
+            </p>
+        </div>
+
+        <!-- Key Insight 2: Division -->
+        <div class="border-l-4 border-black pl-6">
+            <div class="text-5xl font-bold text-black font-mono mb-2">
+                {{ executive_summary.n_divisive_news }}
+            </div>
+            <p class="text-lg text-gray-800 font-mono">
+                noticias dividen claramente a la opinión pública
+            </p>
+            <p class="text-sm text-gray-600 font-mono mt-2">
+                La mayoría del contenido NO es polarizante
+            </p>
+        </div>
+
+        <!-- Key Insight 3: Bridge-Builders -->
+        <div class="border-l-4 border-black pl-6">
+            <div class="text-5xl font-bold text-black font-mono mb-2">
+                {{ executive_summary.n_bridges }}
+            </div>
+            <p class="text-lg text-gray-800 font-mono">
+                votantes actúan como "puentes" entre burbujas
+            </p>
+            <p class="text-sm text-gray-600 font-mono mt-2">
+                Promedio de {{ executive_summary.avg_bridge_votes }} votos por puente
+            </p>
+        </div>
+
+        <!-- Key Insight 4: By Topic -->
+        {% if executive_summary.entity_consensus %}
+        <div class="border-l-4 border-black pl-6">
+            <p class="text-lg text-gray-800 font-mono mb-3">
+                Patrones por temática:
+            </p>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                {% for entity_type, data in executive_summary.entity_consensus.items %}
+                <div class="bg-gray-50 p-3 border border-gray-300">
+                    <div class="text-xs uppercase text-gray-600 font-mono mb-1">
+                        {{ entity_type }}
+                    </div>
+                    <div class="text-2xl font-bold text-black font-mono">
+                        {{ data.consensus|floatformat:0 }}%
+                    </div>
+                    <div class="text-xs text-gray-500 font-mono">
+                        consenso
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        {% endif %}
+    </div>
+
+    <!-- Interpretation Box -->
+    <div class="mt-8 bg-gray-50 border border-gray-300 p-6">
+        <h3 class="text-sm uppercase font-bold text-black font-mono mb-3 tracking-wide">
+            ¿Qué significa esto?
+        </h3>
+        <p class="text-gray-800 font-mono text-sm leading-relaxed">
+            A pesar de las diferencias visibles, existe un <strong>consenso oculto</strong> 
+            significativo en la opinión pública uruguaya. La mayoría de las noticias 
+            generan acuerdo entre las diferentes burbujas, y solo un pequeño porcentaje 
+            de contenido es verdaderamente polarizante. Los votantes "puente" demuestran 
+            que es posible mantener patrones de opinión que conectan perspectivas diversas.
+        </p>
+    </div>
+</div>

--- a/core/templates/clustering/report.html
+++ b/core/templates/clustering/report.html
@@ -1,0 +1,73 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}Reporte de Investigación - Memoria.uy{% endblock %}
+
+{% block content %}
+<div class="container mx-auto px-4 py-8 max-w-7xl">
+    {% if has_data %}
+    
+    <!-- Header -->
+    <div class="mb-12">
+        <h1 class="text-4xl font-bold text-gray-900 mb-3 uppercase tracking-wide font-mono">
+            Reporte de Investigación
+        </h1>
+        <p class="text-lg text-gray-600 font-mono">
+            Análisis de patrones de opinión en Uruguay
+        </p>
+        <div class="mt-2 text-sm text-gray-500 font-mono">
+            Última actualización: {{ cluster_run.completed_at|date:"d/m/Y H:i" }}
+        </div>
+    </div>
+
+    <!-- Executive Summary -->
+    {% include "clustering/components/executive_summary.html" %}
+
+    <!-- Consensus Section -->
+    {% include "clustering/components/consensus_section.html" %}
+
+    <!-- Divisive Section -->
+    {% include "clustering/components/divisive_section.html" %}
+
+    <!-- Bridge-Builders Section -->
+    {% include "clustering/components/bridges_section.html" %}
+
+    <!-- Evolution Section -->
+    {% include "clustering/components/evolution_section.html" %}
+
+    <!-- Bubble Details Section -->
+    {% include "clustering/components/bubble_details.html" %}
+
+    <!-- Actions -->
+    <div class="mt-12 flex gap-4 pb-8">
+        <a href="{% url 'mapa' %}"
+           class="px-6 py-3 bg-black text-white font-mono uppercase text-sm tracking-wide hover:bg-gray-800 transition-colors border-2 border-black">
+            Ver Mapa de Burbujas
+        </a>
+        <a href="{% url 'timeline' %}"
+           class="px-6 py-3 bg-white text-black font-mono uppercase text-sm tracking-wide hover:bg-gray-100 transition-colors border-2 border-black">
+            Volver al Timeline
+        </a>
+    </div>
+
+    {% else %}
+    <!-- No Data State -->
+    <div class="border-2 border-black p-8 bg-white">
+        <h2 class="text-2xl font-bold text-black mb-4 uppercase font-mono">
+            Sin datos disponibles
+        </h2>
+        <p class="text-gray-800 mb-6 font-mono">
+            Se necesitan al menos 50 votantes con 3 votos cada uno para generar el reporte.
+        </p>
+        <a href="{% url 'timeline' %}"
+           class="inline-block px-6 py-3 bg-black text-white font-mono uppercase text-sm tracking-wide hover:bg-gray-800 transition-colors">
+            Ir a Votar Noticias
+        </a>
+    </div>
+    {% endif %}
+</div>
+
+<!-- Load Plotly for visualizations -->
+<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+
+{% endblock %}

--- a/core/templates/clustering/stats.html
+++ b/core/templates/clustering/stats.html
@@ -1,586 +1,345 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block title %}Estadísticas de Burbujas - Memoria.uy{% endblock %}
+{% block title %}Estadísticas - Memoria.uy{% endblock %}
 
 {% block content %}
-<div class="container mx-auto px-4 py-8">
-    <div class="max-w-6xl mx-auto">
-        <!-- Header -->
-        <div class="mb-8">
-            <h1 class="text-3xl font-bold text-gray-900 mb-2">
-                Estadísticas de Burbujas
-            </h1>
-            <p class="text-gray-600">
-                Análisis detallado de los patrones de votación por burbuja
-            </p>
-        </div>
+<div class="container mx-auto px-4 py-8 max-w-7xl">
+    <!-- Header -->
+    <div class="mb-12">
+        <h1 class="text-4xl font-bold text-black mb-3 uppercase tracking-wide font-mono">
+            Estadísticas de Plataforma
+        </h1>
+        <p class="text-lg text-gray-700 font-mono">
+            Métricas de usuarios y actividad de votación
+        </p>
+    </div>
 
-        <!-- User Growth & Activity -->
-        <div class="bg-white rounded-lg shadow p-6 mb-8">
-            <h2 class="text-xl font-bold text-gray-900 mb-4">Usuarios y Actividad</h2>
-            
-            <!-- User Stats Grid -->
-            <div class="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">
-                <div>
-                    <div class="text-sm text-gray-600">Usuarios Totales</div>
-                    <div class="text-2xl font-bold text-indigo-600">
-                        {{ total_users }}
-                    </div>
-                </div>
-                <div>
-                    <div class="text-sm text-gray-600">Nuevos (7d)</div>
-                    <div class="text-2xl font-bold text-green-600">
-                        {{ users_last_7_days }}
-                    </div>
-                </div>
-                <div>
-                    <div class="text-sm text-gray-600">Nuevos (30d)</div>
-                    <div class="text-2xl font-bold text-green-600">
-                        {{ users_last_30_days }}
-                    </div>
-                </div>
-                <div>
-                    <div class="text-sm text-gray-600">Usuarios Activos (30d)</div>
-                    <div class="text-2xl font-bold text-blue-600">
-                        {{ active_users_30_days }}
-                    </div>
-                    <div class="text-xs text-gray-500">
-                        votaron o enviaron news
-                    </div>
-                </div>
-                <div>
-                    <div class="text-sm text-gray-600">Votantes Únicos (30d)</div>
-                    <div class="text-2xl font-bold text-purple-600">
-                        {{ unique_voters_30_days }}
-                    </div>
-                    <div class="text-xs text-gray-500">
-                        incluye anónimos
-                    </div>
+    <!-- Link to Full Report -->
+    <div class="mb-8 border-2 border-black bg-gray-50 p-6">
+        <div class="flex items-center justify-between">
+            <div>
+                <h2 class="text-xl font-bold text-black font-mono uppercase mb-2">
+                    Reporte de Investigación Completo
+                </h2>
+                <p class="text-sm text-gray-700 font-mono">
+                    Análisis profundo: consenso, polarización, bridge-builders y evolución temporal
+                </p>
+            </div>
+            <a href="{% url 'cluster-report' %}"
+               class="px-6 py-3 bg-black text-white font-mono uppercase text-sm tracking-wide hover:bg-gray-800 transition-colors border-2 border-black whitespace-nowrap">
+                Ver Reporte →
+            </a>
+        </div>
+    </div>
+
+    <!-- User Growth & Activity -->
+    <div class="border-2 border-black bg-white p-8 mb-8">
+        <h2 class="text-2xl font-bold text-black mb-6 uppercase font-mono tracking-wide">
+            Usuarios y Actividad
+        </h2>
+        
+        <!-- User Stats Grid -->
+        <div class="grid grid-cols-2 md:grid-cols-5 gap-6 mb-8">
+            <div class="border-2 border-black p-4">
+                <div class="text-xs uppercase text-gray-600 font-mono mb-2">Usuarios Totales</div>
+                <div class="text-3xl font-bold text-black font-mono">
+                    {{ total_users }}
                 </div>
             </div>
+            <div class="border-2 border-black p-4">
+                <div class="text-xs uppercase text-gray-600 font-mono mb-2">Nuevos (7d)</div>
+                <div class="text-3xl font-bold text-black font-mono">
+                    {{ users_last_7_days }}
+                </div>
+            </div>
+            <div class="border-2 border-black p-4">
+                <div class="text-xs uppercase text-gray-600 font-mono mb-2">Nuevos (30d)</div>
+                <div class="text-3xl font-bold text-black font-mono">
+                    {{ users_last_30_days }}
+                </div>
+            </div>
+            <div class="border-2 border-black p-4">
+                <div class="text-xs uppercase text-gray-600 font-mono mb-2">Activos (30d)</div>
+                <div class="text-3xl font-bold text-black font-mono">
+                    {{ active_users_30_days }}
+                </div>
+                <div class="text-xs text-gray-500 font-mono mt-1">
+                    votaron/enviaron
+                </div>
+            </div>
+            <div class="border-2 border-black p-4">
+                <div class="text-xs uppercase text-gray-600 font-mono mb-2">Votantes (30d)</div>
+                <div class="text-3xl font-bold text-black font-mono">
+                    {{ unique_voters_30_days }}
+                </div>
+                <div class="text-xs text-gray-500 font-mono mt-1">
+                    incl. anónimos
+                </div>
+            </div>
+        </div>
 
-            <!-- Charts Row -->
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <!-- New Users Chart -->
-                <div>
-                    <h3 class="text-lg font-semibold text-gray-800 mb-3">
-                        Nuevos Usuarios (Últimos 30 Días)
-                    </h3>
+        <!-- Charts Row -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+            <!-- New Users Chart -->
+            <div>
+                <h3 class="text-sm font-bold text-black font-mono uppercase mb-4 tracking-wide">
+                    Nuevos Usuarios (Últimos 30 Días)
+                </h3>
+                <div class="border-2 border-black p-4 bg-white">
                     <div class="h-64" id="users-chart"></div>
                 </div>
-                
-                <!-- News Submissions Chart -->
-                <div>
-                    <h3 class="text-lg font-semibold text-gray-800 mb-3">
-                        Noticias Enviadas (Últimos 30 Días)
-                    </h3>
-                    <div class="h-64" id="news-chart"></div>
-                    <div class="text-center text-sm text-gray-600 mt-2">
-                        Total de noticias: <span class="font-bold text-gray-900">{{ total_noticias }}</span>
-                    </div>
-                </div>
             </div>
-        </div>
-
-        {% if has_data %}
-        <!-- Clustering Overview -->
-        <div class="bg-white rounded-lg shadow p-6 mb-8">
-            <h2 class="text-xl font-bold text-gray-900 mb-4">Clustering - Resumen</h2>
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
-                <div>
-                    <div class="text-sm text-gray-600">Total de Burbujas</div>
-                    <div class="text-2xl font-bold text-blue-600">
-                        {{ cluster_stats|length }}
-                    </div>
-                </div>
-                <div>
-                    <div class="text-sm text-gray-600">Última Actualización</div>
-                    <div class="text-lg font-semibold text-gray-800">
-                        {{ cluster_run.completed_at|date:"d/m/Y H:i" }}
-                    </div>
-                </div>
-                <div>
-                    <div class="text-sm text-gray-600">Tiempo de Cómputo</div>
-                    <div class="text-lg font-semibold text-gray-800">
-                        {{ cluster_run.computation_time|floatformat:2 }}s
-                    </div>
-                </div>
-                <div>
-                    <div class="text-sm text-gray-600">Total de Votantes</div>
-                    <div class="text-2xl font-bold text-green-600">
-                        {{ cluster_run.n_voters }}
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Votes Over Time -->
-        <div class="bg-white rounded-lg shadow p-6 mb-8">
-            <h2 class="text-xl font-bold text-gray-900 mb-4">
-                Actividad de Votación
-            </h2>
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-                <div>
-                    <div class="text-sm text-gray-600">Total de Votos</div>
-                    <div class="text-2xl font-bold text-purple-600">
-                        {{ total_votes }}
-                    </div>
-                </div>
-                <div>
-                    <div class="text-sm text-gray-600">Últimos 7 Días</div>
-                    <div class="text-2xl font-bold text-blue-600">
-                        {{ votes_last_7_days }}
-                    </div>
-                </div>
-                <div>
-                    <div class="text-sm text-gray-600">Últimos 30 Días</div>
-                    <div class="text-2xl font-bold text-green-600">
-                        {{ votes_last_30_days }}
-                    </div>
-                </div>
-            </div>
-
-            <!-- Votes by Day Chart -->
-            <div class="mt-6">
-                <h3 class="text-lg font-semibold text-gray-800 mb-3">
-                    Votos por Día (Últimos 30 Días)
+            
+            <!-- News Submissions Chart -->
+            <div>
+                <h3 class="text-sm font-bold text-black font-mono uppercase mb-4 tracking-wide">
+                    Noticias Enviadas (Últimos 30 Días)
                 </h3>
-                <div class="h-64" id="votes-chart"></div>
+                <div class="border-2 border-black p-4 bg-white">
+                    <div class="h-64" id="news-chart"></div>
+                    <div class="text-center text-sm text-gray-700 font-mono mt-3 pt-3 border-t-2 border-gray-300">
+                        Total: <span class="font-bold text-black">{{ total_noticias }}</span> noticias
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Votes Activity -->
+    <div class="border-2 border-black bg-white p-8 mb-8">
+        <h2 class="text-2xl font-bold text-black mb-6 uppercase font-mono tracking-wide">
+            Actividad de Votación
+        </h2>
+        
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+            <div class="border-2 border-black p-4">
+                <div class="text-xs uppercase text-gray-600 font-mono mb-2">Total de Votos</div>
+                <div class="text-3xl font-bold text-black font-mono">
+                    {{ total_votes|default:"0" }}
+                </div>
+            </div>
+            <div class="border-2 border-black p-4">
+                <div class="text-xs uppercase text-gray-600 font-mono mb-2">Últimos 7 Días</div>
+                <div class="text-3xl font-bold text-black font-mono">
+                    {{ votes_last_7_days|default:"0" }}
+                </div>
+            </div>
+            <div class="border-2 border-black p-4">
+                <div class="text-xs uppercase text-gray-600 font-mono mb-2">Últimos 30 Días</div>
+                <div class="text-3xl font-bold text-black font-mono">
+                    {{ votes_last_30_days|default:"0" }}
+                </div>
             </div>
         </div>
 
-        <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
-        <script>
-            // User growth chart
-            const usersData = {{ users_by_day|safe }};
-            const usersDates = usersData.map(d => d.day);
-            const usersCounts = usersData.map(d => d.count);
-            
-            Plotly.newPlot('users-chart', 
-                [{
-                    x: usersDates,
-                    y: usersCounts,
-                    type: 'scatter',
-                    mode: 'lines+markers',
-                    fill: 'tozeroy',
-                    name: 'Nuevos Usuarios',
-                    line: { color: '#6366f1', width: 2 },
-                    marker: { size: 6, color: '#6366f1' },
-                    fillcolor: 'rgba(99, 102, 241, 0.1)'
-                }],
-                {
-                    xaxis: { title: 'Fecha', type: 'date' },
-                    yaxis: { title: 'Usuarios' },
-                    hovermode: 'x unified',
-                    showlegend: false,
-                    margin: { l: 50, r: 30, t: 20, b: 50 }
-                },
-                { responsive: true }
-            );
-            
-            // News submissions chart
-            const newsData = {{ news_by_day|safe }};
-            const newsDates = newsData.map(d => d.day);
-            const newsCounts = newsData.map(d => d.count);
-            
-            Plotly.newPlot('news-chart',
-                [{
-                    x: newsDates,
-                    y: newsCounts,
-                    type: 'bar',
-                    name: 'Noticias',
-                    marker: { color: '#10b981' }
-                }],
-                {
-                    xaxis: { title: 'Fecha', type: 'date' },
-                    yaxis: { title: 'Noticias Enviadas' },
-                    hovermode: 'x unified',
-                    showlegend: false,
-                    margin: { l: 50, r: 30, t: 20, b: 50 }
-                },
-                { responsive: true }
-            );
-
-            {% if has_data %}
-            // Prepare data for votes chart
-            const votesData = {{ votes_by_day|safe }};
-            const votesByOpinionData = {{ votes_by_opinion_day|safe }};
-
-            // Total votes per day
-            const dates = votesData.map(d => d.day);
-            const counts = votesData.map(d => d.count);
-
-            // Votes by opinion
-            const opinionMap = {};
-            votesByOpinionData.forEach(d => {
-                if (!opinionMap[d.opinion]) {
-                    opinionMap[d.opinion] = { dates: [], counts: [] };
-                }
-                opinionMap[d.opinion].dates.push(d.day);
-                opinionMap[d.opinion].counts.push(d.count);
-            });
-
-            // Create traces
-            const traces = [
-                {
-                    x: dates,
-                    y: counts,
-                    type: 'scatter',
-                    mode: 'lines+markers',
-                    name: 'Total',
-                    line: { color: '#8b5cf6', width: 2 },
-                    marker: { size: 6 }
-                }
-            ];
-
-            // Add opinion traces
-            const opinionColors = {
-                'buena': '#10b981',
-                'mala': '#ef4444',
-                'neutral': '#6b7280'
-            };
-
-            Object.keys(opinionMap).forEach(opinion => {
-                traces.push({
-                    x: opinionMap[opinion].dates,
-                    y: opinionMap[opinion].counts,
-                    type: 'scatter',
-                    mode: 'lines+markers',
-                    name: opinion.charAt(0).toUpperCase() + opinion.slice(1),
-                    line: { color: opinionColors[opinion], width: 2 },
-                    marker: { size: 5 }
-                });
-            });
-
-            // Layout
-            const layout = {
-                xaxis: {
-                    title: 'Fecha',
-                    type: 'date'
-                },
-                yaxis: {
-                    title: 'Cantidad de Votos'
-                },
-                hovermode: 'x unified',
-                showlegend: true,
-                legend: {
-                    x: 0,
-                    y: 1,
-                    bgcolor: 'rgba(255,255,255,0.8)'
-                },
-                margin: { l: 50, r: 30, t: 30, b: 50 }
-            };
-
-            // Plot
-            Plotly.newPlot('votes-chart', traces, layout, {
-                responsive: true
-            });
-            {% endif %}
-        </script>
-
-        <!-- Cluster Evolution (Sankey Diagram) -->
-        <div class="bg-white rounded-lg shadow p-6 mb-8">
-            <div class="mb-4">
-                <h2 class="text-xl font-bold text-gray-900">
-                    Evolución de Burbujas
-                </h2>
-                <p class="text-sm text-gray-600 mt-1">
-                    Cómo se dividen, fusionan y evolucionan las burbujas a lo largo del tiempo
-                </p>
+        <!-- Votes by Day Chart -->
+        {% if has_data %}
+        <div>
+            <h3 class="text-sm font-bold text-black font-mono uppercase mb-4 tracking-wide">
+                Votos por Día (Últimos 30 Días)
+            </h3>
+            <div class="border-2 border-black p-4 bg-white">
+                <div class="h-80" id="votes-chart"></div>
             </div>
-            
-            <!-- Controls -->
-            <div class="flex flex-wrap gap-4 mb-4 items-center">
-                <div class="flex items-center gap-2">
-                    <label for="runs-select" class="text-sm font-medium text-gray-700">Corridas:</label>
-                    <select id="runs-select" 
-                            class="border border-gray-300 rounded px-3 py-1 text-sm focus:ring-2 focus:ring-blue-500">
-                        <option value="3">3</option>
-                        <option value="5" selected>5</option>
-                        <option value="7">7</option>
-                        <option value="10">10</option>
-                    </select>
-                </div>
-                <div class="flex items-center gap-2">
-                    <label for="mode-select" class="text-sm font-medium text-gray-700">Modo:</label>
-                    <select id="mode-select" 
-                            class="border border-gray-300 rounded px-3 py-1 text-sm focus:ring-2 focus:ring-blue-500">
-                        <option value="spread" selected>Distribuidas en el tiempo</option>
-                        <option value="recent">Últimas consecutivas</option>
-                    </select>
-                </div>
-                <div class="text-xs text-gray-500 ml-auto">
-                    💡 Modo "Distribuidas" muestra cambios reales a lo largo del tiempo
-                </div>
-            </div>
-
-            <!-- Loading State -->
-            <div id="evolution-loading" class="text-center py-12">
-                <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-                <p class="text-gray-600 mt-2">Cargando evolución de burbujas...</p>
-            </div>
-
-            <!-- Chart -->
-            <div id="evolution-chart" class="hidden" style="height: 600px;"></div>
-
-            <!-- Error State -->
-            <div id="evolution-error" class="hidden bg-red-50 border border-red-200 rounded-lg p-4 text-center">
-                <p class="text-red-800 font-medium">Error al cargar datos de evolución</p>
-                <p class="text-red-600 text-sm mt-1" id="evolution-error-message"></p>
-            </div>
-
-            <!-- Legend -->
-            <div class="mt-4 p-4 bg-gray-50 rounded-lg">
-                <div class="text-sm font-semibold text-gray-700 mb-2">Leyenda:</div>
-                <div class="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
-                    <div class="flex items-center gap-2">
-                        <div class="w-12 h-3 rounded" style="background: rgba(0, 200, 0, 0.4);"></div>
-                        <span class="text-gray-700">Continuación (&gt;80%)</span>
-                    </div>
-                    <div class="flex items-center gap-2">
-                        <div class="w-12 h-3 rounded" style="background: rgba(255, 165, 0, 0.4);"></div>
-                        <span class="text-gray-700">División (split)</span>
-                    </div>
-                    <div class="flex items-center gap-2">
-                        <div class="w-12 h-3 rounded" style="background: rgba(0, 100, 255, 0.4);"></div>
-                        <span class="text-gray-700">Fusión (merge)</span>
-                    </div>
-                    <div class="flex items-center gap-2">
-                        <div class="w-12 h-3 rounded" style="background: rgba(100, 100, 100, 0.2);"></div>
-                        <span class="text-gray-700">Migración menor</span>
-                    </div>
-                </div>
-                <p class="text-xs text-gray-500 mt-3">
-                    💡 <strong>Tip:</strong> Pasa el mouse sobre los flujos para ver detalles. Arrastra los nodos para reorganizar.
-                </p>
-            </div>
-        </div>
-
-        <script>
-            // Load cluster evolution data
-            function loadEvolution() {
-                const runs = parseInt(document.getElementById('runs-select').value);
-                const mode = document.getElementById('mode-select').value;
-                const loading = document.getElementById('evolution-loading');
-                const chart = document.getElementById('evolution-chart');
-                const error = document.getElementById('evolution-error');
-                
-                // Show loading state
-                loading.classList.remove('hidden');
-                chart.classList.add('hidden');
-                error.classList.add('hidden');
-                
-                fetch(`/api/clustering/evolution/?runs=${runs}&mode=${mode}`)
-                    .then(response => {
-                        if (!response.ok) {
-                            throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-                        }
-                        return response.json();
-                    })
-                    .then(data => {
-                        // Hide loading, show chart
-                        loading.classList.add('hidden');
-                        chart.classList.remove('hidden');
-                        
-                        // Render Sankey diagram
-                        Plotly.newPlot('evolution-chart', data.data, data.layout, {
-                            responsive: true,
-                            displayModeBar: true,
-                            modeBarButtonsToRemove: ['lasso2d', 'select2d'],
-                        });
-                    })
-                    .catch(err => {
-                        console.error('Error loading evolution data:', err);
-                        loading.classList.add('hidden');
-                        error.classList.remove('hidden');
-                        document.getElementById('evolution-error-message').textContent = err.message;
-                    });
-            }
-            
-            // Initial load
-            loadEvolution();
-            
-            // Listen for control changes
-            document.getElementById('runs-select').addEventListener('change', loadEvolution);
-            document.getElementById('mode-select').addEventListener('change', loadEvolution);
-        </script>
-
-        <!-- Bubble Details -->
-        <div class="space-y-6">
-            {% for stat in cluster_stats %}
-            <div id="{{ stat.cluster.cluster_id }}" class="bg-white rounded-lg shadow overflow-hidden scroll-mt-20">
-                <!-- Bubble Header -->
-                <div class="bg-gradient-to-r from-blue-500 to-blue-600 px-6 py-4">
-                    <div class="flex justify-between items-center">
-                        <div>
-                            <h3 class="text-xl font-bold text-white">
-                                {% if stat.cluster.llm_name %}
-                                    {{ stat.cluster.llm_name }}
-                                {% else %}
-                                    Burbuja {{ stat.cluster.cluster_id }}
-                                {% endif %}
-                            </h3>
-                            {% if stat.cluster.llm_description %}
-                            <p class="text-blue-100 text-sm mt-1">
-                                {{ stat.cluster.llm_description }}
-                            </p>
-                            {% endif %}
-                        </div>
-                        <div class="text-white text-sm">
-                            {{ stat.cluster.size }} votantes
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Bubble Stats -->
-                <div class="p-6">
-                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-                        <div>
-                            <div class="text-sm text-gray-600">Tamaño</div>
-                            <div class="text-xl font-bold text-gray-900">
-                                {{ stat.cluster.size }} votantes
-                            </div>
-                        </div>
-                        <div>
-                            <div class="text-sm text-gray-600">Consenso Promedio</div>
-                            <div class="text-xl font-bold">
-                                <span class="{% if stat.avg_consensus >= 0.7 %}text-green-600{% elif stat.avg_consensus >= 0.5 %}text-yellow-600{% else %}text-red-600{% endif %}">
-                                    {{ stat.avg_consensus|floatformat:2 }}
-                                </span>
-                            </div>
-                            <div class="text-xs text-gray-500">
-                                {% if stat.avg_consensus >= 0.7 %}
-                                    Alto consenso
-                                {% elif stat.avg_consensus >= 0.5 %}
-                                    Consenso moderado
-                                {% else %}
-                                    Bajo consenso
-                                {% endif %}
-                            </div>
-                        </div>
-                        <div>
-                            <div class="text-sm text-gray-600">Centroide</div>
-                            <div class="text-sm font-mono text-gray-700">
-                                ({{ stat.cluster.centroid_x|floatformat:2 }}, {{ stat.cluster.centroid_y|floatformat:2 }})
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Entities Section -->
-                    {% if stat.cluster.top_entities_positive or stat.cluster.top_entities_negative %}
-                    <div class="mb-6 grid grid-cols-1 md:grid-cols-2 gap-4">
-                        {% if stat.cluster.top_entities_positive %}
-                        <div class="bg-green-50 rounded-lg p-4">
-                            <h4 class="text-sm font-semibold text-green-800 mb-2">
-                                👍 Ven positivamente
-                            </h4>
-                            <div class="flex flex-wrap gap-2">
-                                {% for entity in stat.cluster.top_entities_positive %}
-                                <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                                    {{ entity.nombre }}
-                                    <span class="ml-1 text-green-600">({{ entity.count }})</span>
-                                </span>
-                                {% endfor %}
-                            </div>
-                        </div>
-                        {% endif %}
-                        {% if stat.cluster.top_entities_negative %}
-                        <div class="bg-red-50 rounded-lg p-4">
-                            <h4 class="text-sm font-semibold text-red-800 mb-2">
-                                👎 Ven negativamente
-                            </h4>
-                            <div class="flex flex-wrap gap-2">
-                                {% for entity in stat.cluster.top_entities_negative %}
-                                <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
-                                    {{ entity.nombre }}
-                                    <span class="ml-1 text-red-600">({{ entity.count }})</span>
-                                </span>
-                                {% endfor %}
-                            </div>
-                        </div>
-                        {% endif %}
-                    </div>
-                    {% endif %}
-
-                    <!-- Top Noticias -->
-                    {% if stat.top_patterns %}
-                    <div>
-                        <h4 class="text-sm font-semibold text-gray-700 mb-3">
-                            Noticias con Mayor Consenso en esta Burbuja:
-                        </h4>
-                        <div class="space-y-2">
-                            {% for pattern in stat.top_patterns %}
-                            <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                                <div class="flex-1">
-                                    <a href="{% url 'noticia-detail' pattern.noticia.slug %}"
-                                       class="text-sm font-medium text-blue-600 hover:text-blue-800">
-                                        {{ pattern.noticia.mostrar_titulo|truncatewords:15 }}
-                                    </a>
-                                    <div class="flex gap-3 mt-1 text-xs text-gray-600">
-                                        <span class="text-green-600">
-                                            ✓ {{ pattern.count_buena }} buena
-                                        </span>
-                                        <span class="text-red-600">
-                                            ✗ {{ pattern.count_mala }} mala
-                                        </span>
-                                        <span class="text-gray-500">
-                                            ○ {{ pattern.count_neutral }} neutral
-                                        </span>
-                                    </div>
-                                </div>
-                                <div class="ml-4 text-right">
-                                    <div class="text-sm font-bold
-                                        {% if pattern.majority_opinion == 'buena' %}text-green-600
-                                        {% elif pattern.majority_opinion == 'mala' %}text-red-600
-                                        {% else %}text-gray-600{% endif %}">
-                                        {{ pattern.majority_opinion|capfirst }}
-                                    </div>
-                                    <div class="text-xs text-gray-500">
-                                        {{ pattern.consensus_score|floatformat:2 }} consenso
-                                    </div>
-                                </div>
-                            </div>
-                            {% endfor %}
-                        </div>
-                    </div>
-                    {% else %}
-                    <div class="text-sm text-gray-500 text-center py-4">
-                        No hay patrones de votación disponibles para esta burbuja
-                    </div>
-                    {% endif %}
-                </div>
-            </div>
-            {% endfor %}
-        </div>
-
-        <!-- Actions -->
-        <div class="mt-8 flex gap-4">
-            <a href="{% url 'mapa' %}"
-               class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
-                Ver Visualización
-            </a>
-            <a href="{% url 'timeline' %}"
-               class="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300">
-                Volver al Timeline
-            </a>
-        </div>
-
-        {% else %}
-        <!-- No Data State -->
-        <div class="bg-yellow-50 border-l-4 border-yellow-500 p-6 rounded-lg">
-            <h2 class="text-xl font-bold text-yellow-900 mb-2">
-                No hay datos de clustering disponibles
-            </h2>
-            <p class="text-yellow-800 mb-4">
-                Se necesitan al menos 50 votantes con 3 votos cada uno para generar estadísticas.
-            </p>
-            <a href="{% url 'timeline' %}"
-               class="inline-block px-4 py-2 bg-yellow-600 text-white rounded-lg hover:bg-yellow-700">
-                Ir a Votar Noticias
-            </a>
         </div>
         {% endif %}
     </div>
+
+    <!-- Actions -->
+    <div class="flex gap-4 pb-8">
+        <a href="{% url 'cluster-report' %}"
+           class="px-6 py-3 bg-black text-white font-mono uppercase text-sm tracking-wide hover:bg-gray-800 transition-colors border-2 border-black">
+            Ver Reporte Completo
+        </a>
+        <a href="{% url 'mapa' %}"
+           class="px-6 py-3 bg-white text-black font-mono uppercase text-sm tracking-wide hover:bg-gray-100 transition-colors border-2 border-black">
+            Ver Mapa
+        </a>
+        <a href="{% url 'timeline' %}"
+           class="px-6 py-3 bg-white text-black font-mono uppercase text-sm tracking-wide hover:bg-gray-100 transition-colors border-2 border-black">
+            Timeline
+        </a>
+    </div>
 </div>
+
+<!-- Load Plotly for visualizations -->
+<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Monochrome Plotly theme
+    const monochromeLayout = {
+        font: {
+            family: 'IBM Plex Mono, monospace',
+            size: 12,
+            color: '#000000'
+        },
+        plot_bgcolor: '#FFFFFF',
+        paper_bgcolor: '#FFFFFF',
+        xaxis: {
+            gridcolor: '#E5E5E5',
+            linecolor: '#000000',
+            linewidth: 2,
+        },
+        yaxis: {
+            gridcolor: '#E5E5E5',
+            linecolor: '#000000',
+            linewidth: 2,
+        },
+        hovermode: 'x unified',
+        showlegend: false,
+        margin: { l: 50, r: 20, t: 20, b: 50 }
+    };
+    
+    const monochromeConfig = {
+        responsive: true,
+        displayModeBar: false,
+    };
+
+    // User growth chart
+    const usersData = {{ users_by_day|safe }};
+    const usersDates = usersData.map(d => d.day);
+    const usersCounts = usersData.map(d => d.count);
+    
+    Plotly.newPlot('users-chart', 
+        [{
+            x: usersDates,
+            y: usersCounts,
+            type: 'scatter',
+            mode: 'lines+markers',
+            fill: 'tozeroy',
+            line: { color: '#000000', width: 2 },
+            marker: { size: 6, color: '#000000' },
+            fillcolor: 'rgba(0, 0, 0, 0.1)'
+        }],
+        {
+            ...monochromeLayout,
+            xaxis: { 
+                ...monochromeLayout.xaxis,
+                title: 'Fecha', 
+                type: 'date' 
+            },
+            yaxis: { 
+                ...monochromeLayout.yaxis,
+                title: 'Usuarios' 
+            },
+        },
+        monochromeConfig
+    );
+    
+    // News submissions chart
+    const newsData = {{ news_by_day|safe }};
+    const newsDates = newsData.map(d => d.day);
+    const newsCounts = newsData.map(d => d.count);
+    
+    Plotly.newPlot('news-chart',
+        [{
+            x: newsDates,
+            y: newsCounts,
+            type: 'bar',
+            marker: { 
+                color: '#000000',
+                line: { color: '#000000', width: 1 }
+            }
+        }],
+        {
+            ...monochromeLayout,
+            xaxis: { 
+                ...monochromeLayout.xaxis,
+                title: 'Fecha', 
+                type: 'date' 
+            },
+            yaxis: { 
+                ...monochromeLayout.yaxis,
+                title: 'Noticias' 
+            },
+        },
+        monochromeConfig
+    );
+
+    {% if has_data %}
+    // Votes by day chart
+    const votesData = {{ votes_by_day|safe }};
+    const votesByOpinionData = {{ votes_by_opinion_day|safe }};
+
+    // Total votes per day
+    const dates = votesData.map(d => d.day);
+    const counts = votesData.map(d => d.count);
+
+    // Votes by opinion
+    const opinionMap = {};
+    votesByOpinionData.forEach(d => {
+        if (!opinionMap[d.opinion]) {
+            opinionMap[d.opinion] = { dates: [], counts: [] };
+        }
+        opinionMap[d.opinion].dates.push(d.day);
+        opinionMap[d.opinion].counts.push(d.count);
+    });
+
+    // Create traces - monochrome with different patterns
+    const traces = [
+        {
+            x: dates,
+            y: counts,
+            type: 'scatter',
+            mode: 'lines+markers',
+            name: 'Total',
+            line: { color: '#000000', width: 3 },
+            marker: { size: 8, color: '#000000' }
+        }
+    ];
+
+    // Add opinion traces with different shades of gray
+    const opinionColors = {
+        'buena': '#000000',    // Black
+        'mala': '#666666',     // Dark gray
+        'neutral': '#999999'   // Light gray
+    };
+
+    Object.keys(opinionMap).forEach(opinion => {
+        traces.push({
+            x: opinionMap[opinion].dates,
+            y: opinionMap[opinion].counts,
+            type: 'scatter',
+            mode: 'lines+markers',
+            name: opinion.charAt(0).toUpperCase() + opinion.slice(1),
+            line: { 
+                color: opinionColors[opinion], 
+                width: 2,
+                dash: opinion === 'neutral' ? 'dot' : 'solid'
+            },
+            marker: { size: 6, color: opinionColors[opinion] }
+        });
+    });
+
+    Plotly.newPlot('votes-chart', traces, {
+        ...monochromeLayout,
+        xaxis: {
+            ...monochromeLayout.xaxis,
+            title: 'Fecha',
+            type: 'date'
+        },
+        yaxis: {
+            ...monochromeLayout.yaxis,
+            title: 'Votos'
+        },
+        showlegend: true,
+        legend: {
+            x: 0,
+            y: 1,
+            bgcolor: 'rgba(255,255,255,0.9)',
+            bordercolor: '#000000',
+            borderwidth: 1,
+            font: {
+                family: 'IBM Plex Mono, monospace',
+                size: 11,
+                color: '#000000'
+            }
+        },
+        margin: { l: 50, r: 20, t: 20, b: 50 }
+    }, monochromeConfig);
+    {% endif %}
+});
+</script>
 {% endblock %}

--- a/core/tests/test_bridges.py
+++ b/core/tests/test_bridges.py
@@ -1,0 +1,266 @@
+"""
+Tests for bridge-builder identification module.
+"""
+
+import pytest
+import numpy as np
+from django.contrib.auth import get_user_model
+from core.models import VoterClusterRun, VoterCluster, VoterClusterMembership, VoterProjection
+from core.clustering.bridges import (
+    identify_bridge_builders,
+    calculate_bridge_strength,
+    build_bridge_network_data,
+    analyze_bridge_activity,
+)
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestBridgeIdentification:
+    """Test bridge-builder identification."""
+    
+    def test_identify_bridges_basic(self, cluster_run_with_bridges):
+        """Test basic bridge identification."""
+        run = cluster_run_with_bridges
+        
+        bridges = identify_bridge_builders(run, distance_threshold=0.8, min_connections=2)
+        
+        # Should return list
+        assert isinstance(bridges, list)
+        
+        # Check structure
+        if bridges:
+            bridge = bridges[0]
+            assert 'voter_type' in bridge
+            assert 'voter_id' in bridge
+            assert 'connected_clusters' in bridge
+            assert 'bridge_strength' in bridge
+            assert 'n_votes' in bridge
+            
+            # Strength should be valid
+            assert 0 <= bridge['bridge_strength'] <= 1
+            
+            # Should connect min_connections clusters
+            assert len(bridge['connected_clusters']) >= 2
+    
+    def test_bridge_strength_calculation(self):
+        """Test bridge strength calculation between two centroids."""
+        # Bridge exactly at midpoint
+        strength = calculate_bridge_strength(
+            (0.5, 0.5),  # projection at midpoint
+            (0.0, 0.0),  # centroid A
+            (1.0, 1.0),  # centroid B
+        )
+        
+        # Should have high strength (close to midpoint)
+        assert strength > 0.8
+        
+        # Bridge far from both centroids
+        strength_far = calculate_bridge_strength(
+            (2.0, 2.0),  # far away
+            (0.0, 0.0),
+            (1.0, 1.0),
+        )
+        
+        # Should have low strength
+        assert strength_far < 0.5
+    
+    def test_bridge_network_data_structure(self, cluster_run_with_bridges):
+        """Test network data structure for visualization."""
+        run = cluster_run_with_bridges
+        
+        network = build_bridge_network_data(run, distance_threshold=0.8)
+        
+        assert 'nodes' in network
+        assert 'edges' in network
+        assert 'n_clusters' in network
+        assert 'n_bridges' in network
+        
+        # Nodes should have cluster and bridge types
+        node_types = {node['type'] for node in network['nodes']}
+        if len(network['nodes']) > 0:
+            assert 'cluster' in node_types or 'bridge' in node_types
+        
+        # Edges should connect bridges to clusters
+        if network['edges']:
+            edge = network['edges'][0]
+            assert 'source' in edge
+            assert 'target' in edge
+            assert 'weight' in edge
+            assert 0 <= edge['weight'] <= 1
+    
+    def test_bridge_activity_analysis(self, cluster_run_with_bridges):
+        """Test bridge activity statistics."""
+        run = cluster_run_with_bridges
+        bridges = identify_bridge_builders(run, distance_threshold=0.8)
+        
+        stats = analyze_bridge_activity(bridges)
+        
+        assert 'total_bridges' in stats
+        assert 'avg_votes' in stats
+        assert 'avg_connections' in stats
+        
+        if bridges:
+            assert stats['total_bridges'] == len(bridges)
+            assert stats['avg_votes'] >= 0
+            assert stats['avg_connections'] >= 2  # min_connections default
+            assert 'strongest_bridge' in stats
+            assert 'most_active_bridge' in stats
+    
+    def test_no_bridges_case(self, cluster_run_no_bridges):
+        """Test handling when no bridges exist."""
+        run = cluster_run_no_bridges
+        
+        bridges = identify_bridge_builders(run, distance_threshold=0.1)  # Very tight threshold
+        
+        assert bridges == []
+        
+        stats = analyze_bridge_activity(bridges)
+        assert stats['total_bridges'] == 0
+
+
+@pytest.fixture
+def cluster_run_with_bridges(db):
+    """Create a clustering run with bridge voters."""
+    user1 = User.objects.create_user(username='user1')
+    user2 = User.objects.create_user(username='user2')
+    user3 = User.objects.create_user(username='user3')  # Bridge voter
+    
+    # Create run
+    run = VoterClusterRun.objects.create(
+        status='completed',
+        n_voters=3,
+        n_noticias=5,
+        n_clusters=2,
+    )
+    
+    # Create two clusters far apart
+    cluster1 = VoterCluster.objects.create(
+        run=run,
+        cluster_type='group',
+        cluster_id=1,
+        size=1,
+        centroid_x=0.0,
+        centroid_y=0.0,
+    )
+    cluster2 = VoterCluster.objects.create(
+        run=run,
+        cluster_type='group',
+        cluster_id=2,
+        size=2,
+        centroid_x=1.0,
+        centroid_y=1.0,
+    )
+    
+    # Create memberships
+    VoterClusterMembership.objects.create(
+        cluster=cluster1,
+        voter_type='user',
+        voter_id=str(user1.id),
+        distance_to_centroid=0.1,
+    )
+    VoterClusterMembership.objects.create(
+        cluster=cluster2,
+        voter_type='user',
+        voter_id=str(user2.id),
+        distance_to_centroid=0.1,
+    )
+    VoterClusterMembership.objects.create(
+        cluster=cluster2,
+        voter_type='user',
+        voter_id=str(user3.id),
+        distance_to_centroid=0.5,
+    )
+    
+    # Create projections - user3 is between clusters (bridge)
+    VoterProjection.objects.create(
+        run=run,
+        voter_type='user',
+        voter_id=str(user1.id),
+        projection_x=0.0,
+        projection_y=0.0,
+        n_votes_cast=5,
+    )
+    VoterProjection.objects.create(
+        run=run,
+        voter_type='user',
+        voter_id=str(user2.id),
+        projection_x=1.0,
+        projection_y=1.0,
+        n_votes_cast=5,
+    )
+    VoterProjection.objects.create(
+        run=run,
+        voter_type='user',
+        voter_id=str(user3.id),
+        projection_x=0.5,  # Between clusters
+        projection_y=0.5,
+        n_votes_cast=10,  # More active
+    )
+    
+    return run
+
+
+@pytest.fixture
+def cluster_run_no_bridges(db):
+    """Create a clustering run with no bridges (tight clusters)."""
+    user1 = User.objects.create_user(username='user1')
+    user2 = User.objects.create_user(username='user2')
+    
+    run = VoterClusterRun.objects.create(
+        status='completed',
+        n_voters=2,
+        n_noticias=5,
+        n_clusters=2,
+    )
+    
+    # Create two clusters very far apart
+    cluster1 = VoterCluster.objects.create(
+        run=run,
+        cluster_type='group',
+        cluster_id=1,
+        size=1,
+        centroid_x=0.0,
+        centroid_y=0.0,
+    )
+    cluster2 = VoterCluster.objects.create(
+        run=run,
+        cluster_type='group',
+        cluster_id=2,
+        size=1,
+        centroid_x=10.0,  # Very far
+        centroid_y=10.0,
+    )
+    
+    VoterClusterMembership.objects.create(
+        cluster=cluster1,
+        voter_type='user',
+        voter_id=str(user1.id),
+        distance_to_centroid=0.0,
+    )
+    VoterClusterMembership.objects.create(
+        cluster=cluster2,
+        voter_type='user',
+        voter_id=str(user2.id),
+        distance_to_centroid=0.0,
+    )
+    
+    VoterProjection.objects.create(
+        run=run,
+        voter_type='user',
+        voter_id=str(user1.id),
+        projection_x=0.0,
+        projection_y=0.0,
+        n_votes_cast=5,
+    )
+    VoterProjection.objects.create(
+        run=run,
+        voter_type='user',
+        voter_id=str(user2.id),
+        projection_x=10.0,
+        projection_y=10.0,
+        n_votes_cast=5,
+    )
+    
+    return run

--- a/core/tests/test_consensus.py
+++ b/core/tests/test_consensus.py
@@ -1,0 +1,174 @@
+"""
+Tests for consensus analysis module.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from core.models import Noticia, Voto, VoterClusterRun, VoterCluster, VoterClusterMembership, VoterProjection
+from core.clustering.consensus import (
+    calculate_cross_cluster_consensus,
+    calculate_consensus_news,
+    calculate_divisive_news,
+    calculate_polarization_score,
+)
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestConsensusCalculation:
+    """Test consensus metric calculations."""
+    
+    def test_cross_cluster_consensus_basic(self, cluster_run_with_data):
+        """Test basic cross-cluster consensus calculation."""
+        run = cluster_run_with_data
+        
+        results = calculate_cross_cluster_consensus(run, min_votes_per_cluster=1)
+        
+        # Should return list of dicts
+        assert isinstance(results, list)
+        if results:
+            assert 'consensus_score' in results[0]
+            assert 'polarization_score' in results[0]
+            assert 'noticia' in results[0]
+            assert 0 <= results[0]['consensus_score'] <= 1
+            assert 0 <= results[0]['polarization_score'] <= 1
+    
+    def test_consensus_news_filtering(self, cluster_run_with_data):
+        """Test filtering for high consensus news."""
+        run = cluster_run_with_data
+        
+        consensus_news = calculate_consensus_news(run, consensus_threshold=0.5, top_n=10)
+        
+        # All returned news should have consensus above threshold
+        for item in consensus_news:
+            assert item['consensus_score'] >= 0.5
+        
+        # Should be sorted by consensus (highest first)
+        if len(consensus_news) > 1:
+            assert consensus_news[0]['consensus_score'] >= consensus_news[-1]['consensus_score']
+    
+    def test_divisive_news_sorting(self, cluster_run_with_data):
+        """Test divisive news sorting by polarization."""
+        run = cluster_run_with_data
+        
+        divisive = calculate_divisive_news(run, top_n=10)
+        
+        # Should be sorted by polarization (highest first)
+        if len(divisive) > 1:
+            assert divisive[0]['polarization_score'] >= divisive[-1]['polarization_score']
+    
+    def test_polarization_score_structure(self, cluster_run_with_data):
+        """Test polarization score returns correct structure."""
+        run = cluster_run_with_data
+        
+        result = calculate_polarization_score(run)
+        
+        assert 'polarization_score' in result
+        assert 'consensus_score' in result
+        assert 'n_consensus_news' in result
+        assert 'n_divisive_news' in result
+        assert 'n_total_news' in result
+        
+        # Scores should be valid
+        assert 0 <= result['polarization_score'] <= 1
+        assert 0 <= result['consensus_score'] <= 1
+        assert result['n_total_news'] >= 0
+    
+    def test_empty_run(self):
+        """Test handling of run with no data."""
+        run = VoterClusterRun.objects.create(
+            status='completed',
+            n_voters=0,
+            n_noticias=0,
+            n_clusters=0,
+        )
+        
+        results = calculate_cross_cluster_consensus(run)
+        assert results == []
+        
+        polarization = calculate_polarization_score(run)
+        assert polarization['n_total_news'] == 0
+
+
+@pytest.fixture
+def cluster_run_with_data(db):
+    """Create a clustering run with test data."""
+    # Create users and news
+    user1 = User.objects.create_user(username='user1', email='user1@test.com')
+    user2 = User.objects.create_user(username='user2', email='user2@test.com')
+    
+    noticia1 = Noticia.objects.create(
+        enlace='https://example.com/news1',
+        meta_titulo='Test News 1',
+    )
+    noticia2 = Noticia.objects.create(
+        enlace='https://example.com/news2',
+        meta_titulo='Test News 2',
+    )
+    
+    # Create votes
+    Voto.objects.create(usuario=user1, noticia=noticia1, opinion='buena')
+    Voto.objects.create(usuario=user2, noticia=noticia1, opinion='buena')
+    Voto.objects.create(usuario=user1, noticia=noticia2, opinion='mala')
+    Voto.objects.create(usuario=user2, noticia=noticia2, opinion='buena')
+    
+    # Create clustering run
+    run = VoterClusterRun.objects.create(
+        status='completed',
+        n_voters=2,
+        n_noticias=2,
+        n_clusters=2,
+    )
+    
+    # Create clusters
+    cluster1 = VoterCluster.objects.create(
+        run=run,
+        cluster_type='group',
+        cluster_id=1,
+        size=1,
+        centroid_x=0.0,
+        centroid_y=0.0,
+    )
+    cluster2 = VoterCluster.objects.create(
+        run=run,
+        cluster_type='group',
+        cluster_id=2,
+        size=1,
+        centroid_x=1.0,
+        centroid_y=1.0,
+    )
+    
+    # Create memberships
+    VoterClusterMembership.objects.create(
+        cluster=cluster1,
+        voter_type='user',
+        voter_id=str(user1.id),
+        distance_to_centroid=0.0,
+    )
+    VoterClusterMembership.objects.create(
+        cluster=cluster2,
+        voter_type='user',
+        voter_id=str(user2.id),
+        distance_to_centroid=0.0,
+    )
+    
+    # Create projections
+    VoterProjection.objects.create(
+        run=run,
+        voter_type='user',
+        voter_id=str(user1.id),
+        projection_x=0.0,
+        projection_y=0.0,
+        n_votes_cast=2,
+    )
+    VoterProjection.objects.create(
+        run=run,
+        voter_type='user',
+        voter_id=str(user2.id),
+        projection_x=1.0,
+        projection_y=1.0,
+        n_votes_cast=2,
+    )
+    
+    return run

--- a/memoria/urls.py
+++ b/memoria/urls.py
@@ -46,10 +46,15 @@ from core.api_clustering import (
 from core.views_clustering import (
     ClusterVisualizationView,
     ClusterStatsView,
+    ClusterReportView,
     cluster_data_json,
     cluster_evolution_json,
     cluster_og_image,
     upload_cluster_og_image,
+    consensus_data_json,
+    bridges_data_json,
+    polarization_timeline_json,
+    cluster_stability_json,
 )
 from memoria.views import health_check, robots_txt, favicon
 
@@ -146,6 +151,27 @@ urlpatterns = [
         upload_cluster_og_image,
         name="api-upload-cluster-og-image",
     ),
+    # New clustering analysis APIs
+    path(
+        "api/clustering/consensus/",
+        consensus_data_json,
+        name="api-consensus-data",
+    ),
+    path(
+        "api/clustering/bridges/",
+        bridges_data_json,
+        name="api-bridges-data",
+    ),
+    path(
+        "api/clustering/polarization-timeline/",
+        polarization_timeline_json,
+        name="api-polarization-timeline",
+    ),
+    path(
+        "api/clustering/stability/",
+        cluster_stability_json,
+        name="api-cluster-stability",
+    ),
     # Clustering UI endpoint - mapa de burbujas
     path(
         "mapa/",
@@ -156,6 +182,11 @@ urlpatterns = [
         "clusters/stats/",
         ClusterStatsView.as_view(),
         name="cluster-stats",
+    ),
+    path(
+        "clusters/report/",
+        ClusterReportView.as_view(),
+        name="cluster-report",
     ),
     path("accounts/", include("allauth.urls")),
     path("__reload__/", include("django_browser_reload.urls")),


### PR DESCRIPTION
- Introduced a new `ClusterReportView` for detailed analysis of cluster consensus, divisive issues, and bridge-builders, enhancing insights for researchers.
- Updated `CLAUDE.md` to document the new report structure and its sections, including executive summary and temporal evolution metrics.
- Deprecated the previous analytics page at `/clusters/stats/`, maintaining it for backward compatibility while directing users to the new report.
- Added new JSON endpoints for consensus analysis, bridge-builder data, and polarization metrics, improving data accessibility for external applications.
- Enhanced the `stats.html` template to link to the new report and updated visualizations for user and voting activity.