### PR TITLE
Add daily staff summary email task and enhance reengagement email con…

### DIFF
--- a/memoria/celery.py
+++ b/memoria/celery.py
@@ -31,6 +31,13 @@ app.conf.beat_schedule = {
             'min_votes_per_voter': 3,
         },
     },
+    'send-daily-staff-summary': {
+        'task': 'core.tasks.send_daily_staff_summary',
+        'schedule': crontab(
+            hour=int(os.getenv("DAILY_SUMMARY_HOUR", "9")),
+            minute=int(os.getenv("DAILY_SUMMARY_MINUTE", "0")),
+        ),  # Run once per day at 9 AM by default
+    },
 }
 
 if os.getenv("ENABLE_REENGAGEMENT_EMAILS", "False") == "True":


### PR DESCRIPTION
…tent

- Implemented a new task `send_daily_staff_summary` to send a daily summary email to staff, including new articles, users, and votes from the last 24 hours.
- Enhanced the `send_reengagement_emails` function to include HTML formatted emails with clickable links for better user engagement.
- Updated the Celery beat schedule to run the daily summary task at 9 AM by default, improving automated reporting for staff.